### PR TITLE
Target correct project

### DIFF
--- a/.github/workflows/firebase-hosting-merge-main.yml
+++ b/.github/workflows/firebase-hosting-merge-main.yml
@@ -88,4 +88,4 @@ jobs:
           credentials_json: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SCROLLBARWEB2 }}'
 
       - name: Deploy functions
-        run: firebase deploy --only functions
+        run: firebase deploy --only functions --project "${{ secrets.FIREBASE_PROJECT_ID }}"


### PR DESCRIPTION
Necessary to deploy functions step in github actions, since it otherwise defaults to what is configured in `.firebaserc` which points to our dev environment.