### PR TITLE
Remove cyclic dependency

### DIFF
--- a/src/pages/members/Profile.tsx
+++ b/src/pages/members/Profile.tsx
@@ -31,7 +31,7 @@ export default function Profile() {
         setUserData(data);
       }
     })();
-  }, [currentUser, getProfileData]);
+  }, [currentUser]);
 
   const setStudyLine = (studyLine: string) => {
     if (!currentUser) return;


### PR DESCRIPTION
A cyclic dependency meant we kept refetching the profile data for the user indefinitely.