### PR TITLE
Internal Get Help page

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches-ignore: 
       - main
-      - dev
 permissions:
   checks: write
   contents: read

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,6 @@ function App() {
                 {/* --- Protected Routes --- */}
                 <Route element={<ProtectedRoutes />}>
                   <Route element={<TenderMenu />}>
-                    <Route path="/members/profile" element={<Profile />} />
                     <Route
                       path="/tenders/allshifts"
                       element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import FooterBar from "./components/HomePage/FooterBar";
 import Register from "./pages/Register";
 import Shifts from "./pages/members/Shifts";
 import Profile from "./pages/members/Profile";
+import GetHelpPage from "./pages/members/GetHelpPage";
 import { TenderMenu } from "./components/HomePage/TenderMenu";
 import { Role, ShiftFiltering } from "./types/types-file";
 import EventManagement from "./pages/admin/EventManagement/EventManagement";
@@ -79,6 +80,7 @@ function App() {
                         />
                       }
                     />
+                    <Route path="/tenders/gethelp" element={<GetHelpPage />} />
                     <Route path="/members/profile" element={<Profile />} />
                     {/* --- Admin Routes --- */}
                     <Route element={<RoleProtectedRoute />}>

--- a/src/components/HomePage/TenderMenu.tsx
+++ b/src/components/HomePage/TenderMenu.tsx
@@ -9,6 +9,7 @@ import { useWindowSize } from "../../hooks/useWindowSize";
 import { UserAvatar } from "../UserAvatar";
 import { Loading } from "../Loading";
 import { Role } from "../../types/types-file";
+import useSettings from "../../hooks/useSettings";
 
 interface TenderMenuProps {
   children?: ReactNode;
@@ -18,9 +19,11 @@ type MenuItem = Required<MenuProps>['items'][number];
 
 export const TenderMenu = ({ children }: TenderMenuProps) => {
   const { currentUser, loading, logout } = useAuth();
+  const { settingsState } = useSettings();
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const { isMobile } = useWindowSize();
+  const getHelpLabel = settingsState.settings.getHelpTitle || "Get help";
 
   const items: MenuItem[] = [
     {
@@ -36,7 +39,7 @@ export const TenderMenu = ({ children }: TenderMenuProps) => {
       key: 'tenders/upforgrabs',
     },
     {
-      label: "Get help",
+      label: getHelpLabel,
       key: 'tenders/gethelp',
     }
   ];

--- a/src/components/HomePage/TenderMenu.tsx
+++ b/src/components/HomePage/TenderMenu.tsx
@@ -34,6 +34,10 @@ export const TenderMenu = ({ children }: TenderMenuProps) => {
     {
       label: "Up for grabs",
       key: 'tenders/upforgrabs',
+    },
+    {
+      label: "Get help",
+      key: 'tenders/gethelp',
     }
   ];
 

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect } from "react";
+import { List } from "antd";
+import { MailOutlined } from "@ant-design/icons";
+import { UserAvatar } from "./UserAvatar";
+import { getTenderDisplayName } from "../pages/members/helpers";
+import { BoardRole, StudyLine, Tender } from "../types/types-file";
+import { getStudyLines } from "../firebase/api/authentication";
+
+let cachedStudylines: StudyLine[] | null = null;
+let cachePromise: Promise<StudyLine[]> | null = null;
+
+export type TenderWithRole = Tender & { role?: BoardRole };
+
+type UserListProps = {
+  users: TenderWithRole[];
+  className?: string;
+  getContactEmail?: (user: TenderWithRole) => string | undefined;
+};
+
+export function UserList({ users, className, getContactEmail }: UserListProps) {
+  const [studylines, setStudylines] = React.useState<StudyLine[]>([]);
+
+  if (users.some((u) => u.role)) {
+    users.sort((a, b) => {
+      if (a.role && b.role) {
+        return (a.role.sortingIndex ?? 0) - (b.role.sortingIndex ?? 0);
+      }
+      return 0;
+    });
+  }
+
+  useEffect(() => {
+    // If already cached, use it immediately
+    if (cachedStudylines) {
+      setStudylines(cachedStudylines);
+      return;
+    }
+
+    // If fetch is already in progress, wait for it
+    if (cachePromise) {
+      cachePromise.then((data) => {
+        setStudylines(data);
+      });
+      return;
+    }
+
+    // Otherwise, fetch and cache
+    cachePromise = getStudyLines()
+      .then((response) => {
+        const mapped: StudyLine[] = response.map((doc: unknown) => doc as StudyLine);
+        cachedStudylines = mapped;
+        setStudylines(mapped);
+        return mapped;
+      })
+      .catch((error) => {
+        console.error("Failed to fetch study lines: " + error.message);
+        cachePromise = null; // Reset on error
+        return [];
+      });
+  }, []);
+
+  return (
+    <List
+      className={className}
+      grid={{ gutter: 16, column: 10, xs: 3, sm: 3, md: 5, lg: 8, xl: 10 }}
+      dataSource={users}
+      renderItem={(user) => {
+        const contactEmail = getContactEmail?.(user);
+
+        return (
+          <List.Item>
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+              {user.role && (
+                <div style={{ marginTop: 8, textAlign: "center", fontWeight: "bold" }}>{user.role.name}</div>
+              )}
+              <UserAvatar user={user} size={95} showHats={false} />
+              <div style={{ marginTop: 8, textAlign: "center" }}>{getTenderDisplayName(user)}</div>
+              <div style={{ marginTop: 8, textAlign: "center", color: "grey" }}>
+                {studylines.find((sl) => sl.id === user.studyline)?.abbreviation?.toLocaleUpperCase()}
+              </div>
+              {contactEmail && (
+                <a
+                  href={`mailto:${contactEmail}`}
+                  className="user-list-email-chip"
+                  title={contactEmail}
+                >
+                  <MailOutlined />
+                  <span>{contactEmail}</span>
+                </a>
+              )}
+            </div>
+          </List.Item>
+        );
+      }}
+    />
+  );
+}

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { List } from "antd";
 import { MailOutlined } from "@ant-design/icons";
 import { UserAvatar } from "./UserAvatar";
@@ -20,14 +20,18 @@ type UserListProps = {
 export function UserList({ users, className, getContactEmail }: UserListProps) {
   const [studylines, setStudylines] = React.useState<StudyLine[]>([]);
 
-  if (users.some((u) => u.role)) {
-    users.sort((a, b) => {
+  const sortedUsers = useMemo(() => {
+    if (!users.some((u) => u.role)) {
+      return users;
+    }
+
+    return [...users].sort((a, b) => {
       if (a.role && b.role) {
         return (a.role.sortingIndex ?? 0) - (b.role.sortingIndex ?? 0);
       }
       return 0;
     });
-  }
+  }, [users]);
 
   useEffect(() => {
     // If already cached, use it immediately
@@ -63,7 +67,7 @@ export function UserList({ users, className, getContactEmail }: UserListProps) {
     <List
       className={className}
       grid={{ gutter: 16, column: 10, xs: 3, sm: 3, md: 5, lg: 8, xl: 10 }}
-      dataSource={users}
+      dataSource={sortedUsers}
       renderItem={(user) => {
         const contactEmail = getContactEmail?.(user);
 

--- a/src/components/UserList.tsx
+++ b/src/components/UserList.tsx
@@ -15,9 +15,10 @@ type UserListProps = {
   users: TenderWithRole[];
   className?: string;
   getContactEmail?: (user: TenderWithRole) => string | undefined;
+  columns: number;
 };
 
-export function UserList({ users, className, getContactEmail }: UserListProps) {
+export function UserList({ users, className, getContactEmail, columns }: UserListProps) {
   const [studylines, setStudylines] = React.useState<StudyLine[]>([]);
 
   const sortedUsers = useMemo(() => {
@@ -66,7 +67,7 @@ export function UserList({ users, className, getContactEmail }: UserListProps) {
   return (
     <List
       className={className}
-      grid={{ gutter: 16, column: 10, xs: 3, sm: 3, md: 5, lg: 8, xl: 10 }}
+      grid={{ gutter: 16, column: columns }}
       dataSource={sortedUsers}
       renderItem={(user) => {
         const contactEmail = getContactEmail?.(user);

--- a/src/components/UserPage/ExistingUsersTab.tsx
+++ b/src/components/UserPage/ExistingUsersTab.tsx
@@ -102,6 +102,7 @@ export const ExistingUsersTab = () => {
       filters: [
         { text: "Admins", value: Role.ADMIN },
         { text: "Board members", value: Role.BOARD },
+        { text: "HR", value: Role.HR },
         { text: "Newbies", value: Role.NEWBIE },
         { text: "Anchors", value: Role.ANCHOR },
       ],

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { message } from "antd";
+import { streamSettings, updateSettings, uploadFile } from "../firebase/api/settings";
+import { Settings } from "../types/types-file";
+
+type SettingsState = {
+  loading: boolean;
+  settings: Settings;
+};
+
+type SettingsContextType = {
+  settingsState: SettingsState;
+  updateSetting: (field: string, displayName: string, value: any) => void;
+  uploadSettingsFile: (file: File, settingsKey: string) => Promise<string>;
+};
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [settingsState, setSettingsState] = useState<SettingsState>({
+    loading: true,
+    settings: {} as Settings,
+  });
+
+  useEffect(() => {
+    setSettingsState((prev) => ({ ...prev, loading: true }));
+
+    const unsubscribe = streamSettings((snapshot) => {
+      if (snapshot.exists()) {
+        const data = snapshot.data() as Settings;
+        setSettingsState({ loading: false, settings: data });
+      } else {
+        setSettingsState({ loading: false, settings: {} as Settings });
+      }
+    });
+
+    return unsubscribe;
+  }, []);
+
+  const updateSetting = (field: string, displayName: string, value: any) => {
+    updateSettings(field, value);
+    message.success(`Updated ${displayName} successfully`);
+  };
+
+  const uploadSettingsFile = async (file: File, settingsKey: string): Promise<string> => {
+    return uploadFile(file, settingsKey);
+  };
+
+  const value = useMemo(
+    () => ({
+      settingsState,
+      updateSetting,
+      uploadSettingsFile,
+    }),
+    [settingsState]
+  );
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;
+};
+
+export const useSettingsContext = (): SettingsContextType => {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error("useSettings must be used within a SettingsProvider");
+  }
+  return context;
+};

--- a/src/firebase/api/boardRoles.ts
+++ b/src/firebase/api/boardRoles.ts
@@ -30,7 +30,7 @@ export const streamRoles = (next: (snapshot: QuerySnapshot<DocumentData>) => voi
 };
 
 export const addRole = async (role: { name: string }) => {
-  const data: any = { name: role.name };
+  const data: any = { name: role.name, contactEmail: "" };
   return addDoc(getRolesCollection(), data);
 };
 
@@ -40,7 +40,7 @@ export const addRole = async (role: { name: string }) => {
  */
 export const updateRole = async (
   id: string,
-  data: Partial<{ name: string; assignedUser: Tender; sortingIndex: number }>
+  data: Partial<{ name: string; assignedUser: Tender; sortingIndex: number; contactEmail: string }>
 ) => {
   const docRef = doc(getRolesCollection(), id);
   const updateData: any = {};
@@ -50,6 +50,9 @@ export const updateRole = async (
   }
   if (data.sortingIndex !== undefined) {
     updateData.sortingIndex = data.sortingIndex;
+  }
+  if (data.contactEmail !== undefined) {
+    updateData.contactEmail = data.contactEmail;
   }
   return updateDoc(docRef, updateData);
 };

--- a/src/hooks/useBoardRoles.ts
+++ b/src/hooks/useBoardRoles.ts
@@ -5,15 +5,15 @@ import { message } from 'antd';
 import { DocumentReference, getDoc } from 'firebase/firestore';
 
 type BoardRolesState = {
-    loading: boolean;
-    boardRoles: BoardRole[];
+  loading: boolean;
+  boardRoles: BoardRole[];
 }
 
 type UseBoardRolesReturn = {
-    boardRolesState: BoardRolesState;
-    updateBoardRole: (id: string, update: { name?: string; assignedUser?: Tender; sortingIndex?: number }) => void;
-    addBoardRole: (name: string) => void;
-    deleteBoardRole: (id: string) => void;
+  boardRolesState: BoardRolesState;
+  updateBoardRole: (id: string, update: { name?: string; assignedUser?: Tender; sortingIndex?: number; contactEmail?: string }) => void;
+  addBoardRole: (name: string) => void;
+  deleteBoardRole: (id: string) => void;
 }
 
 // Type used to represent a board role but with a reference to the user
@@ -23,6 +23,7 @@ interface FirebaseBoardRole {
   name: string;
   assignedUserRef?: DocumentReference;
   sortingIndex?: number;
+  contactEmail?: string;
 }
 
 export default function useBoardRoles(): UseBoardRolesReturn {
@@ -49,6 +50,7 @@ export default function useBoardRoles(): UseBoardRolesReturn {
             name: data.name,
             assignedUser,
             sortingIndex: data.sortingIndex,
+            contactEmail: data.contactEmail,
           } as BoardRole;
         }));
 
@@ -62,7 +64,7 @@ export default function useBoardRoles(): UseBoardRolesReturn {
     return unsubscribe;
   }, []);
 
-  const updateBoardRole = (id: string, update: { name?: string; assignedUser?: Tender; sortingIndex?: number }) => {
+  const updateBoardRole = (id: string, update: { name?: string; assignedUser?: Tender; sortingIndex?: number; contactEmail?: string }) => {
     updateRole(id, update);
     if (update.name) {
       message.success(`Updated role name to ${update.name} successfully`);
@@ -70,6 +72,8 @@ export default function useBoardRoles(): UseBoardRolesReturn {
       message.success(`Assigned user ${update.assignedUser.displayName} to role successfully`);
     } else if (update.sortingIndex !== undefined) {
       message.success(`Updated role sorting index to ${update.sortingIndex} successfully`);
+    } else if (update.contactEmail !== undefined) {
+      message.success("Updated role contact email successfully");
     } else {
       message.success('Updated board role successfully');
     }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,40 +1,5 @@
-import { useEffect, useState } from 'react';
-import { streamSettings, updateSettings, uploadFile } from '../firebase/api/settings';
-import { Settings } from '../types/types-file';
-import { message } from 'antd';
-
-type SettingsState = {
-    loading: boolean;
-    settings: Settings;
-}
+import { useSettingsContext } from "../contexts/SettingsContext";
 
 export default function useSettings() {
-  const [settingsState, setSettingsState] = useState<SettingsState>({
-    loading: true,
-    settings: {} as Settings,
-  });
-
-  useEffect(() => {
-    setSettingsState((prev) => ({ ...prev, loading: true }));
-    const unsubscribe = streamSettings((snapshot) => {
-      if (snapshot.exists()) {
-        const data = snapshot.data() as Settings;
-        setSettingsState((prev) => ({ ...prev, settings: data, loading: false }));
-      } else {
-        setSettingsState((prev) => ({ ...prev, settings: {} as Settings, loading: false }));
-      }
-    });
-    return unsubscribe;
-  }, []);
-
-  const updateSetting = (field: string, displayName: string, value: any) => {
-    updateSettings(field, value);
-    message.success(`Updated ${displayName} successfully`);
-  };
-
-  const uploadSettingsFile = async (file: File, settingsKey: string): Promise<string> => {
-    return uploadFile(file, settingsKey);
-  };
-
-  return { settingsState, updateSetting, uploadSettingsFile };
+  return useSettingsContext();
 }

--- a/src/index.css
+++ b/src/index.css
@@ -85,3 +85,32 @@ button:focus-visible {
   background-color: transparent !important;
   color: #d7ce00 !important;
 }
+
+.user-list-centered .ant-row {
+  justify-content: center;
+}
+
+.user-list-email-chip {
+  margin-top: 8px;
+  max-width: 220px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  color: #1f2937;
+  font-size: 12px;
+  line-height: 20px;
+  text-decoration: none;
+}
+
+.user-list-email-chip span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-list-email-chip:hover {
+  background: #e5e7eb;
+  color: #111827;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import '@ant-design/v5-patch-for-react-19';
 import { AuthProvider } from './contexts/AuthContext';
 import { EventProvider } from './contexts/EventContext.tsx';
 import { TenderProvider } from './contexts/TenderContext.tsx';
+import { SettingsProvider } from './contexts/SettingsContext.tsx';
 
 
 createRoot(document.getElementById('root')!).render(
@@ -14,7 +15,9 @@ createRoot(document.getElementById('root')!).render(
     <AuthProvider>
       <EventProvider>
         <TenderProvider>
-          <App />
+          <SettingsProvider>
+            <App />
+          </SettingsProvider>
         </TenderProvider>
       </EventProvider>
     </AuthProvider>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -13,12 +13,15 @@ import CountDown from '../components/EventPage/EventCountDown'
 import {useNextEvent}  from '../hooks/useEvents'
 import { useLocation } from 'react-router-dom'
 import { UserList, TenderWithRole } from '../components/UserList'
+import { useWindowSize } from '../hooks/useWindowSize'
 
 export default function HomePage() {
   const { settingsState } = useSettings();
   const { tenderState } = useTenders();
   const { boardRolesState } = useBoardRoles();
   const { nextEvent, loading: eventLoading } = useNextEvent();
+  const { isMobile } = useWindowSize();
+
   // Board members: use boardRoles, sorted by sortingIndex, showing assigned users
   const boardMembers = useMemo(() => {
     if (!boardRolesState.boardRoles) return [];
@@ -185,7 +188,7 @@ export default function HomePage() {
             <Title level={2} style={{ scrollMarginTop: '135px' }} id="boardMembers">
               The Board
             </Title>
-            <UserList users={boardMembers} />
+            <UserList users={boardMembers} columns={isMobile ? 3 : 10} />
           </Col>
         </Row>
 
@@ -203,7 +206,7 @@ export default function HomePage() {
             <Title level={2} style={{ scrollMarginTop: '135px' }} id="volunteers">
               The Volunteers
             </Title>
-            <UserList users={activeTenders} />
+            <UserList users={activeTenders} columns={isMobile ? 3 : 10} />
           </Col>
         </Row>
       </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo } from 'react'
-import { Button, Col, Divider, Layout, Row, List } from 'antd'
+import { useEffect, useMemo } from 'react'
+import { Button, Col, Divider, Layout, Row } from 'antd'
 import Title from 'antd/es/typography/Title'
 import Paragraph from 'antd/es/typography/Paragraph'
 import HeaderBar from '../components/HomePage/HeaderBar'
@@ -7,18 +7,12 @@ import useSettings from '../hooks/useSettings'
 import MDEditor from '@uiw/react-md-editor'
 import useTenders from '../hooks/useTenders'
 import useBoardRoles from '../hooks/useBoardRoles'
-import { UserAvatar } from '../components/UserAvatar'
-import { getTenderDisplayName } from './members/helpers'
-import { BoardRole, Role, StudyLine, Tender } from '../types/types-file'
-import { getStudyLines } from '../firebase/api/authentication'
+import { Role } from '../types/types-file'
 import { Loading } from '../components/Loading'
 import CountDown from '../components/EventPage/EventCountDown'
 import {useNextEvent}  from '../hooks/useEvents'
 import { useLocation } from 'react-router-dom'
-
-let cachedStudylines: StudyLine[] | null = null;
-let cachePromise: Promise<StudyLine[]> | null = null;
-type TenderWithRole = Tender & { role?: BoardRole };
+import { UserList, TenderWithRole } from '../components/UserList'
 
 export default function HomePage() {
   const { settingsState } = useSettings();
@@ -216,65 +210,3 @@ export default function HomePage() {
     </Layout>
   )
 }
-
-const UserList = ({ users }: { users: TenderWithRole[]}) => {
-  const [studylines, setStudylines] = React.useState<StudyLine[]>([]);
-
-  if (users.some(u => u.role)) {
-    users.sort((a, b) => {
-      if (a.role && b.role) {
-        return (a.role.sortingIndex ?? 0) - (b.role.sortingIndex ?? 0);
-      }
-      return 0;
-    });
-  }
-
-  useEffect(() => {
-    // If already cached, use it immediately
-    if (cachedStudylines) {
-      setStudylines(cachedStudylines);
-      return;
-    }
-
-    // If fetch is already in progress, wait for it
-    if (cachePromise) {
-      cachePromise.then((data) => {
-        setStudylines(data);
-      });
-      return;
-    }
-
-    // Otherwise, fetch and cache
-    cachePromise = getStudyLines()
-      .then((response) => {
-        const mapped: StudyLine[] = response.map((doc: unknown) => doc as StudyLine);
-        cachedStudylines = mapped;
-        setStudylines(mapped);
-        return mapped;
-      })
-      .catch((error) => {
-        console.error("Failed to fetch study lines: " + error.message);
-        cachePromise = null; // Reset on error
-        return [];
-      });
-  }, []);
-
-  return (
-    <List
-      grid={{ gutter: 16, column: 10, xs: 3, sm: 3, md: 5, lg: 8, xl: 10 }}
-      dataSource={users}
-      renderItem={(user) => (
-        <List.Item>
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            {user.role && (
-              <div style={{ marginTop: 8, textAlign: 'center', fontWeight: 'bold' }}>{user.role.name}</div>
-            )}
-            <UserAvatar user={user} size={95} showHats={false} />
-            <div style={{ marginTop: 8, textAlign: 'center' }}>{getTenderDisplayName(user)}</div>
-            <div style={{ marginTop: 8, textAlign: 'center', color: 'grey' }}>{studylines.find(sl => sl.id === user.studyline)?.abbreviation?.toLocaleUpperCase()}</div>
-          </div>
-        </List.Item>
-      )}
-    />
-  );
-};

--- a/src/pages/admin/BoardManagement/BoardManagementPage.tsx
+++ b/src/pages/admin/BoardManagement/BoardManagementPage.tsx
@@ -16,6 +16,8 @@ export default function BoardManagementPage() {
   const [editingRoleValue, setEditingRoleValue] = useState<string>("");
   const [editingSortingIndexId, setEditingSortingIndexId] = useState<string | null>(null);
   const [editingSortingIndexValue, setEditingSortingIndexValue] = useState<number>(0);
+  const [editingContactEmailId, setEditingContactEmailId] = useState<string | null>(null);
+  const [editingContactEmailValue, setEditingContactEmailValue] = useState<string>("");
 
   useEffect(() => {
     if (!tenderState.loading && Array.isArray(tenderState.tenders)) {
@@ -150,6 +152,46 @@ export default function BoardManagementPage() {
       ),
     },
     {
+      title: 'Contact Email',
+      dataIndex: 'contactEmail',
+      key: 'contactEmail',
+      render: (_: string, record: BoardRole) => {
+        if (editingContactEmailId === record.id) {
+          const commit = () => {
+            const trimmed = editingContactEmailValue.trim();
+            if (trimmed !== (record.contactEmail ?? "")) {
+              updateBoardRole(record.id, { contactEmail: trimmed });
+            }
+            setEditingContactEmailId(null);
+          };
+
+          return (
+            <Input
+              value={editingContactEmailValue}
+              autoFocus
+              placeholder="role-email@scrollbar.dk"
+              style={{ minWidth: 220 }}
+              onChange={(e) => setEditingContactEmailValue(e.target.value)}
+              onBlur={commit}
+              onPressEnter={commit}
+            />
+          );
+        }
+
+        return (
+          <span
+            style={{ cursor: 'pointer', minWidth: 220, display: 'inline-block' }}
+            onClick={() => {
+              setEditingContactEmailId(record.id);
+              setEditingContactEmailValue(record.contactEmail ?? "");
+            }}
+          >
+            {record.contactEmail || "Click to set"}
+          </span>
+        );
+      },
+    },
+    {
       title: 'Actions',
       key: 'actions',
       render: (_: any, record: BoardRole) => (
@@ -163,7 +205,7 @@ export default function BoardManagementPage() {
         </Popconfirm>
       ),
     },
-  ], [editingRoleId, editingRoleValue, editingSortingIndexId, editingSortingIndexValue, boardMembers, handleAssignUser, handleDeleteRole, updateBoardRole]);
+  ], [editingRoleId, editingRoleValue, editingSortingIndexId, editingSortingIndexValue, editingContactEmailId, editingContactEmailValue, boardMembers, handleAssignUser, handleDeleteRole, updateBoardRole]);
 
   if (boardRolesState.loading || tenderState.loading) {
     return <Loading />;

--- a/src/pages/admin/GlobalSettingsPage.tsx
+++ b/src/pages/admin/GlobalSettingsPage.tsx
@@ -175,6 +175,18 @@ const GlobalSettingsPage = () => {
       value: settingsState.settings.homepageDescription,
     },
     {
+      key: "getHelpTitle",
+      inputType: "text",
+      label: "Get help page title",
+      value: settingsState.settings.getHelpTitle,
+    },
+    {
+      key: "getHelpDescription",
+      inputType: "textarea",
+      label: "Get help page description",
+      value: settingsState.settings.getHelpDescription,
+    },
+    {
       key: "joinScrollBarLink",
       inputType: "text",
       label: "Join ScrollBar link",

--- a/src/pages/members/GetHelpPage.tsx
+++ b/src/pages/members/GetHelpPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { Col, Divider, Empty, Layout, Row, Typography } from "antd";
+import MDEditor from "@uiw/react-md-editor";
 import useBoardRoles from "../../hooks/useBoardRoles";
 import useSettings from "../../hooks/useSettings";
 import useTenders from "../../hooks/useTenders";
@@ -10,7 +11,7 @@ import { TenderWithRole, UserList } from "../../components/UserList";
 import { useWindowSize } from "../../hooks/useWindowSize";
 
 const { Content } = Layout;
-const { Title, Paragraph } = Typography;
+const { Title } = Typography;
 
 export default function GetHelpPage() {
   const { settingsState } = useSettings();
@@ -54,9 +55,18 @@ export default function GetHelpPage() {
         <Row justify="center">
           <Col xs={24} lg={18}>
             <Title level={2} style={{ textAlign: "center" }}>{settingsState.settings.getHelpTitle}</Title>
-            <Paragraph style={{ fontSize: 16, maxWidth: 840, textAlign: "center", margin: "0 auto" }}>
-              {settingsState.settings.getHelpDescription}
-            </Paragraph>
+            <MDEditor.Markdown
+              style={{
+                fontSize: "16px",
+                lineHeight: "32px",
+                textAlign: "center",
+                color: "black",
+                background: "white",
+                maxWidth: 840,
+                margin: "0 auto",
+              }}
+              source={settingsState.settings.getHelpDescription}
+            />
           </Col>
         </Row>
 

--- a/src/pages/members/GetHelpPage.tsx
+++ b/src/pages/members/GetHelpPage.tsx
@@ -1,0 +1,97 @@
+import { useMemo } from "react";
+import { Col, Divider, Empty, Layout, Row, Typography } from "antd";
+import useBoardRoles from "../../hooks/useBoardRoles";
+import useSettings from "../../hooks/useSettings";
+import useTenders from "../../hooks/useTenders";
+import { Loading } from "../../components/Loading";
+import { getTenderDisplayName } from "./helpers";
+import { BoardRole, Role, Tender } from "../../types/types-file";
+import { TenderWithRole, UserList } from "../../components/UserList";
+
+const { Content } = Layout;
+const { Title, Paragraph } = Typography;
+
+export default function GetHelpPage() {
+  const { settingsState } = useSettings();
+  const { boardRolesState } = useBoardRoles();
+  const { tenderState } = useTenders();
+
+  const boardMembers = useMemo<TenderWithRole[]>(() => {
+    if (!boardRolesState.boardRoles) return [];
+
+    return [...boardRolesState.boardRoles]
+      .sort((a, b) => (a.sortingIndex ?? 0) - (b.sortingIndex ?? 0))
+      .filter(
+        (role): role is typeof role & { assignedUser: Tender } =>
+          !!role.assignedUser?.uid
+      )
+      .map((role) => ({
+        ...role.assignedUser,
+        role: {
+          id: role.id,
+          name: role.name,
+          sortingIndex: role.sortingIndex,
+          contactEmail: role.contactEmail,
+        } as BoardRole,
+      }));
+  }, [boardRolesState.boardRoles]);
+
+  const hrMembers = useMemo<TenderWithRole[]>(() => {
+    return tenderState.tenders
+      .filter((tender) => tender.active && tender.roles?.includes(Role.HR))
+      .sort((a, b) => getTenderDisplayName(a).localeCompare(getTenderDisplayName(b)));
+  }, [tenderState.tenders]);
+
+  if (settingsState.loading || boardRolesState.loading || tenderState.loading) {
+    return <Loading centerOverlay={true} />;
+  }
+
+  return (
+    <Layout style={{ minHeight: "100vh", background: "#fff" }}>
+      <Content style={{ padding: "32px 24px 40px" }}>
+        <Row justify="center">
+          <Col xs={24} lg={18}>
+            <Title level={2} style={{ textAlign: "center" }}>{settingsState.settings.getHelpTitle}</Title>
+            <Paragraph style={{ fontSize: 16, maxWidth: 840, textAlign: "center", margin: "0 auto" }}>
+              {settingsState.settings.getHelpDescription}
+            </Paragraph>
+          </Col>
+        </Row>
+
+        <Divider />
+
+        <Row justify="center">
+          <Col xs={24} lg={18}>
+            <Title level={3} style={{ textAlign: "center" }}>Board Members</Title>
+            {boardMembers.length ? (
+              <UserList
+                users={boardMembers}
+                className="user-list-centered"
+                getContactEmail={(user) => user.role?.contactEmail}
+              />
+            ) : (
+              <Empty description="No board members available right now." />
+            )}
+          </Col>
+        </Row>
+
+        <Divider />
+
+        <Row justify="center">
+          <Col xs={24} lg={18}>
+            <Title level={3} style={{ textAlign: "center" }}>HR</Title>
+            {hrMembers.length ? (
+              <UserList
+                users={hrMembers}
+                className="user-list-centered"
+                getContactEmail={(user) => user.email}
+              />
+            ) : (
+              <Empty description="No HR contacts available right now." />
+            )}
+          </Col>
+        </Row>
+      </Content>
+    </Layout>
+  );
+}

--- a/src/pages/members/GetHelpPage.tsx
+++ b/src/pages/members/GetHelpPage.tsx
@@ -7,6 +7,7 @@ import { Loading } from "../../components/Loading";
 import { getTenderDisplayName } from "./helpers";
 import { BoardRole, Role, Tender } from "../../types/types-file";
 import { TenderWithRole, UserList } from "../../components/UserList";
+import { useWindowSize } from "../../hooks/useWindowSize";
 
 const { Content } = Layout;
 const { Title, Paragraph } = Typography;
@@ -15,6 +16,7 @@ export default function GetHelpPage() {
   const { settingsState } = useSettings();
   const { boardRolesState } = useBoardRoles();
   const { tenderState } = useTenders();
+  const { isMobile } = useWindowSize();
 
   const boardMembers = useMemo<TenderWithRole[]>(() => {
     if (!boardRolesState.boardRoles) return [];
@@ -68,6 +70,7 @@ export default function GetHelpPage() {
                 users={boardMembers}
                 className="user-list-centered"
                 getContactEmail={(user) => user.role?.contactEmail}
+                columns={isMobile ? 2 : 5}
               />
             ) : (
               <Empty description="No board members available right now." />
@@ -85,6 +88,7 @@ export default function GetHelpPage() {
                 users={hrMembers}
                 className="user-list-centered"
                 getContactEmail={(user) => user.email}
+                columns={isMobile ? 2 : 4}
               />
             ) : (
               <Empty description="No HR contacts available right now." />

--- a/src/pages/members/helpers.ts
+++ b/src/pages/members/helpers.ts
@@ -70,6 +70,8 @@ export const roleToColor = (role: Role): string => {
       return "green";
     case Role.BOARD:
       return "blue";
+    case Role.HR:
+      return "red";
     case Role.TENDER_MANAGER:
       return "orange";
     case Role.SHIFT_MANAGER:
@@ -99,6 +101,8 @@ export const roleToLabel = (role: Role): string => {
       return "Newbie";
     case Role.BOARD:
       return "Board";
+    case Role.HR:
+      return "HR";
     case Role.TENDER_MANAGER:
       return "Tender Manager";
     case Role.SHIFT_MANAGER:

--- a/src/types/types-file.ts
+++ b/src/types/types-file.ts
@@ -47,6 +47,8 @@ export interface Settings {
   hero: string;
   homepageTitle: string;
   homepageDescription: string;
+  getHelpTitle: string;
+  getHelpDescription: string;
   joinScrollBarLink: string;
   joinScrollBarText: string;
   joinScrollBarTitle: string;
@@ -184,6 +186,7 @@ export enum Role {
   ANCHOR = "anchor",
   NEWBIE = "newbie",
   BOARD = "board",
+  HR = "hr",
   TENDER_MANAGER = "tender_manager",
   SHIFT_MANAGER = "shift_manager",
   EVENT_MANAGER = "event_manager",
@@ -228,4 +231,5 @@ export interface BoardRole {
   name: string;
   assignedUser?: Tender;
   sortingIndex?: number;
+  contactEmail?: string;
 }


### PR DESCRIPTION
Internal get help page (fixes #28)

Shows board and HR members alongside their emails. All the configuration (page text/title, role selection and email selection is also included)                                                                                                                                                                                            