### PR TITLE
Application form on website

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,5 +8,7 @@ export const calendar = functions.https.onRequest({invoker: "public", region: "e
 
 // Export mail service functions individually so the emulator can detect them.
 export const sendEmailInvite = mailservice.sendEmailInvite;
+export const sendRejectedApplicationEmail = mailservice.sendRejectedApplicationEmail;
+export const sendTemplateTestEmail = mailservice.sendTemplateTestEmail;
 export const sendShiftGrabbedConfirmation = mailservice.sendShiftGrabbedConfirmation;
 export const resetUserMail = adminChangeUserEmail;

--- a/functions/src/mailservice.ts
+++ b/functions/src/mailservice.ts
@@ -1,6 +1,5 @@
 import FormData from 'form-data';
 import Mailgun from 'mailgun.js';
-import * as functions from 'firebase-functions/v2';
 import * as admin from 'firebase-admin';
 import { onDocumentCreated, onDocumentUpdated } from 'firebase-functions/v2/firestore';
 import { Tender } from '../src/types/types-file';
@@ -23,6 +22,9 @@ export const sendEmailInvite = onDocumentCreated(
     { document: 'invites/{email}', region: 'europe-west1' },
     async (event: any) => {
         const email = event.params?.email;
+        const data = event.data?.data ? event.data.data() : {};
+        const fullName = data?.fullName || 'ScrollBar Applicant';
+        const bodyText = data?.bodyText?.trim?.() || "You have been invited to ScrollBar Tender site. Please follow your invitation link to continue.";
         if (!email) {
             console.warn('sendEmailInvite: missing email param');
             return;
@@ -30,9 +32,13 @@ export const sendEmailInvite = onDocumentCreated(
         try {
             await mailgun.messages.create(mailgunDomain, {
                 to: email,
-                from: `ScrollBar Web <no-reply@${mailgunDomain}>`,
+                from: `ScrollBar Web <board@${mailgunDomain}>`,
                 subject: 'You have been invited to ScrollBar Tender site',
                 template: 'invite_template',
+                'h:X-Mailgun-Variables': JSON.stringify({
+                    name: fullName,
+                    bodyText,
+                }),
             });
             return;
         } catch (err) {
@@ -73,6 +79,74 @@ export const sendShiftGrabbedConfirmation = onDocumentUpdated(
             return;
         } catch (err) {
             console.error('sendShiftGrabbedConfirmation error', err);
+        }
+    }
+);
+
+export const sendRejectedApplicationEmail = onDocumentCreated(
+    { document: 'env/{_env}/applicationRejectionEmails/{docId}', region: 'europe-west1' },
+    async (event: any) => {
+        const data = event.data?.data ? event.data.data() : {};
+        const email = data?.email;
+        const fullName = data?.fullName || 'ScrollBar Applicant';
+        const bodyText = data?.bodyText?.trim?.() || 'Thank you for your application. Unfortunately, we are not able to offer you a position at this time.';
+
+        if (!email) {
+            console.warn('sendRejectedApplicationEmail: missing email');
+            return;
+        }
+
+        try {
+            await mailgun.messages.create(mailgunDomain, {
+                to: email,
+                from: `ScrollBar Web <board@${mailgunDomain}>`,
+                subject: 'Regarding your ScrollBar application',
+                template: 'application_rejected_template',
+                'h:X-Mailgun-Variables': JSON.stringify({
+                    name: fullName,
+                    bodyText,
+                }),
+            });
+            return;
+        } catch (err) {
+            console.error('sendRejectedApplicationEmail error', err);
+        }
+    }
+);
+
+export const sendTemplateTestEmail = onDocumentCreated(
+    { document: 'env/{_env}/emailTemplateTests/{docId}', region: 'europe-west1' },
+    async (event: any) => {
+        const data = event.data?.data ? event.data.data() : {};
+        const templateType = data?.templateType;
+        const email = data?.email;
+        const fullName = data?.fullName || 'ScrollBar Applicant';
+        const bodyText = data?.bodyText?.trim?.() || '';
+
+        if (!email || (templateType !== 'invite' && templateType !== 'rejection')) {
+            console.warn('sendTemplateTestEmail: invalid payload');
+            return;
+        }
+
+        try {
+            const template = templateType === 'invite' ? 'invite_template' : 'application_rejected_template';
+            const subject = templateType === 'invite'
+                ? '[TEST] You have been invited to ScrollBar Tender site'
+                : '[TEST] Regarding your ScrollBar application';
+
+            await mailgun.messages.create(mailgunDomain, {
+                to: email,
+                from: `ScrollBar Web <board@${mailgunDomain}>`,
+                subject,
+                template,
+                'h:X-Mailgun-Variables': JSON.stringify({
+                    name: fullName,
+                    bodyText,
+                }),
+            });
+            return;
+        } catch (err) {
+            console.error('sendTemplateTestEmail error', err);
         }
     }
 );

--- a/functions/src/mailservice.ts
+++ b/functions/src/mailservice.ts
@@ -18,6 +18,21 @@ const mailgun = new Mailgun(FormData).client({
 
 const mailgunDomain = process.env.MAILGUN_DOMAIN || 'dev.scrollbar.dk';
 
+const updateApplicationDeliveryStatus = async (
+    envName: string | undefined,
+    applicationId: string | undefined,
+    status: 'success' | 'failed'
+) => {
+    if (!envName || !applicationId) return;
+    try {
+        await db.doc(`env/${envName}/applications/${applicationId}`).update({
+            emailDeliveryStatus: status,
+        });
+    } catch (error) {
+        console.error('updateApplicationDeliveryStatus error', error);
+    }
+};
+
 export const sendEmailInvite = onDocumentCreated(
     { document: 'invites/{email}', region: 'europe-west1' },
     async (event: any) => {
@@ -25,6 +40,8 @@ export const sendEmailInvite = onDocumentCreated(
         const data = event.data?.data ? event.data.data() : {};
         const fullName = data?.fullName || 'ScrollBar Applicant';
         const bodyText = data?.bodyText?.trim?.() || "You have been invited to ScrollBar Tender site. Please follow your invitation link to continue.";
+        const applicationId = data?.applicationId;
+        const applicationEnv = data?.applicationEnv;
         if (!email) {
             console.warn('sendEmailInvite: missing email param');
             return;
@@ -40,9 +57,11 @@ export const sendEmailInvite = onDocumentCreated(
                     bodyText,
                 }),
             });
+            await updateApplicationDeliveryStatus(applicationEnv, applicationId, 'success');
             return;
         } catch (err) {
             console.error('sendEmailInvite error', err);
+            await updateApplicationDeliveryStatus(applicationEnv, applicationId, 'failed');
         }
     }
 );
@@ -86,7 +105,9 @@ export const sendShiftGrabbedConfirmation = onDocumentUpdated(
 export const sendRejectedApplicationEmail = onDocumentCreated(
     { document: 'env/{_env}/applicationRejectionEmails/{docId}', region: 'europe-west1' },
     async (event: any) => {
+        const envName = event.params?._env;
         const data = event.data?.data ? event.data.data() : {};
+        const applicationId = data?.applicationId;
         const email = data?.email;
         const fullName = data?.fullName || 'ScrollBar Applicant';
         const bodyText = data?.bodyText?.trim?.() || 'Thank you for your application. Unfortunately, we are not able to offer you a position at this time.';
@@ -107,9 +128,11 @@ export const sendRejectedApplicationEmail = onDocumentCreated(
                     bodyText,
                 }),
             });
+            await updateApplicationDeliveryStatus(envName, applicationId, 'success');
             return;
         } catch (err) {
             console.error('sendRejectedApplicationEmail error', err);
+            await updateApplicationDeliveryStatus(envName, applicationId, 'failed');
         }
     }
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 
 import HomePage from "./pages/HomePage";
+import ApplyPage from "./pages/ApplyPage";
 import LoginPage from "./pages/LoginPage";
 import NotFoundPage from "./pages/NotFoundPage"; // A 404 page
 import ProtectedRoutes from "./routes/ProtectedRoutes";
@@ -28,6 +29,7 @@ import { InactiveUserPage } from "./pages/InactiveUserPage";
 import dayjs from 'dayjs';
 import updateLocale from 'dayjs/plugin/updateLocale';
 import BoardManagementPage from "./pages/admin/BoardManagement/BoardManagementPage";
+import ApplicationsReviewPage from "./pages/admin/ApplicationsReviewPage";
 
 
 function App() {
@@ -55,6 +57,7 @@ function App() {
                 <Route path="/" element={<HomePage />} />
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/register" element={<Register />} />
+                <Route path="/apply" element={<ApplyPage />} />
                 <Route path="/events" element={<EventsPage />} /> 
                 <Route path="/deletedUser" element={<InactiveUserPage />} /> 
 
@@ -122,6 +125,16 @@ function App() {
                       <Route
                         path="admin/shifts"
                         element={<ShiftManagement />}
+                      />
+                    </Route>
+                    <Route
+                      element={
+                        <RoleProtectedRoute requiredRole={Role.BOARD} />
+                      }
+                    >
+                      <Route
+                        path="admin/applications"
+                        element={<ApplicationsReviewPage />}
                       />
                     </Route>
                     <Route

--- a/src/components/HomePage/TenderMenu.tsx
+++ b/src/components/HomePage/TenderMenu.tsx
@@ -79,6 +79,10 @@ export const TenderMenu = ({ children }: TenderMenuProps) => {
         label: 'Manage Internal Events',
         key: 'admin/internalEvents',
       });
+      adminItems.push({
+        label: 'Applications Review',
+        key: 'admin/applications',
+      });
     }
     if (currentUser?.isAdmin) {
       adminItems.push({

--- a/src/firebase/api/applications.ts
+++ b/src/firebase/api/applications.ts
@@ -5,6 +5,7 @@ import {
   DocumentData,
   DocumentSnapshot,
   doc,
+  writeBatch,
   onSnapshot,
   orderBy,
   QuerySnapshot,
@@ -39,9 +40,15 @@ type SubmitApplicationPayload = {
 };
 
 type QueueRejectedEmailPayload = {
+  id: string;
   email: string;
   fullName: string;
   bodyText?: string;
+};
+
+export type QueueEmailResult = {
+  successful: string[];
+  failed: Array<{ id: string; email: string; error: unknown }>;
 };
 
 type QueueTemplateTestEmailPayload = {
@@ -93,6 +100,7 @@ export const submitApplication = async (payload: SubmitApplicationPayload) => {
       applicationFilePath: uploadedApplicationPath,
       photoPath: uploadedPhotoPath,
       decision: "pending",
+      emailDeliveryStatus: "pending",
       createdAt: serverTimestamp(),
     });
   } catch (error) {
@@ -135,10 +143,10 @@ export const submitApplicationRound = async (submittedByUid: string) => {
   }, { merge: true });
 };
 
-export const queueRejectedApplicationEmails = async (rejections: QueueRejectedEmailPayload[]) => {
+export const queueRejectedApplicationEmails = async (rejections: QueueRejectedEmailPayload[]): Promise<QueueEmailResult> => {
   const collectionRef = collection(doc(collection(db, "env"), env), "applicationRejectionEmails");
 
-  await Promise.all(
+  const results = await Promise.allSettled(
     rejections.map((rejection) =>
       addDoc(collectionRef, {
         email: rejection.email,
@@ -148,6 +156,39 @@ export const queueRejectedApplicationEmails = async (rejections: QueueRejectedEm
       })
     )
   );
+
+  const successful: string[] = [];
+  const failed: Array<{ id: string; email: string; error: unknown }> = [];
+
+  results.forEach((result, index) => {
+    const rejection = rejections[index];
+    if (result.status === "fulfilled") {
+      successful.push(rejection.id);
+    } else {
+      failed.push({ id: rejection.id, email: rejection.email, error: result.reason });
+    }
+  });
+
+  return { successful, failed };
+};
+
+export const updateApplicationEmailDeliveryStatuses = async (
+  updates: Array<{
+    id: string;
+    emailDeliveryStatus?: "pending" | "success" | "failed";
+  }>
+) => {
+  if (!updates.length) return;
+
+  const batch = writeBatch(db);
+  updates.forEach((update) => {
+    const docRef = doc(getApplicationsCollection(), update.id);
+    const payload: Record<string, string> = {};
+    if (update.emailDeliveryStatus) payload.emailDeliveryStatus = update.emailDeliveryStatus;
+    batch.update(docRef, payload);
+  });
+
+  await batch.commit();
 };
 
 export const queueTemplateTestEmail = async (payload: QueueTemplateTestEmailPayload) => {

--- a/src/firebase/api/applications.ts
+++ b/src/firebase/api/applications.ts
@@ -38,6 +38,19 @@ type SubmitApplicationPayload = {
   photoFile: File;
 };
 
+type QueueRejectedEmailPayload = {
+  email: string;
+  fullName: string;
+  bodyText?: string;
+};
+
+type QueueTemplateTestEmailPayload = {
+  templateType: "invite" | "rejection";
+  email: string;
+  fullName: string;
+  bodyText?: string;
+};
+
 const uploadApplicationFile = async (file: File, applicantEmail: string, fileTag: string) => {
   const extension = getExtension(file.name);
   const safeEmail = applicantEmail.replace(/[^a-zA-Z0-9._-]/g, "_").toLowerCase();
@@ -96,6 +109,32 @@ export const submitApplicationRound = async (submittedByUid: string) => {
     submittedAt: serverTimestamp(),
     submittedByUid,
   }, { merge: true });
+};
+
+export const queueRejectedApplicationEmails = async (rejections: QueueRejectedEmailPayload[]) => {
+  const collectionRef = collection(doc(collection(db, "env"), env), "applicationRejectionEmails");
+
+  await Promise.all(
+    rejections.map((rejection) =>
+      addDoc(collectionRef, {
+        email: rejection.email,
+        fullName: rejection.fullName,
+        bodyText: rejection.bodyText ?? "",
+        createdAt: serverTimestamp(),
+      })
+    )
+  );
+};
+
+export const queueTemplateTestEmail = async (payload: QueueTemplateTestEmailPayload) => {
+  const collectionRef = collection(doc(collection(db, "env"), env), "emailTemplateTests");
+  return addDoc(collectionRef, {
+    templateType: payload.templateType,
+    email: payload.email,
+    fullName: payload.fullName,
+    bodyText: payload.bodyText ?? "",
+    createdAt: serverTimestamp(),
+  });
 };
 
 export const resetAndDeleteApplicationRound = async (

--- a/src/firebase/api/applications.ts
+++ b/src/firebase/api/applications.ts
@@ -1,0 +1,123 @@
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  DocumentData,
+  DocumentSnapshot,
+  doc,
+  onSnapshot,
+  orderBy,
+  QuerySnapshot,
+  query,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+} from "firebase/firestore";
+import {
+  deleteObject,
+  ref,
+  uploadBytes,
+} from "firebase/storage";
+import { db, storage } from "../index";
+import { getExtension } from "./common";
+
+const env = import.meta.env.VITE_APP_ENV as string;
+
+const getApplicationsCollection = () =>
+  collection(doc(collection(db, "env"), env), "applications");
+
+const getRoundMetaRef = () =>
+  doc(collection(doc(collection(db, "env"), env), "meta"), "applications");
+
+type SubmitApplicationPayload = {
+  fullName: string;
+  email: string;
+  studyline: string;
+  comment: string;
+  file: File;
+  photoFile: File;
+};
+
+const uploadApplicationFile = async (file: File, applicantEmail: string, fileTag: string) => {
+  const extension = getExtension(file.name);
+  const safeEmail = applicantEmail.replace(/[^a-zA-Z0-9._-]/g, "_").toLowerCase();
+  const path = `applications/${env}/${Date.now()}-${safeEmail}-${fileTag}.${extension}`;
+  const storageRef = ref(storage, path);
+
+  await uploadBytes(storageRef, file, {
+    contentType: file.type,
+  });
+
+  return { path };
+};
+
+export const submitApplication = async (payload: SubmitApplicationPayload) => {
+  const uploaded = await uploadApplicationFile(payload.file, payload.email, "application");
+  const uploadedPhoto = await uploadApplicationFile(payload.photoFile, payload.email, "photo");
+
+  return addDoc(getApplicationsCollection(), {
+    fullName: payload.fullName,
+    email: payload.email,
+    studyline: payload.studyline,
+    comment: payload.comment ?? "",
+    applicationFilePath: uploaded.path,
+    photoPath: uploadedPhoto.path,
+    decision: "pending",
+    createdAt: serverTimestamp(),
+  });
+};
+
+export const streamApplications = (
+  next: (snapshot: QuerySnapshot<DocumentData>) => void,
+  error: (error: Error) => void
+) => {
+  const q = query(getApplicationsCollection(), orderBy("createdAt", "asc"));
+  return onSnapshot(q, next, error);
+};
+
+export const updateApplicationDecision = async (
+  id: string,
+  decision: "maybe" | "accept" | "reject"
+) => {
+  return updateDoc(doc(getApplicationsCollection(), id), {
+    decision,
+  });
+};
+
+export const streamApplicationRoundMeta = (
+  next: (snapshot: DocumentSnapshot<DocumentData>) => void,
+  error: (error: Error) => void
+) => {
+  return onSnapshot(getRoundMetaRef(), next, error);
+};
+
+export const submitApplicationRound = async (submittedByUid: string) => {
+  return setDoc(getRoundMetaRef(), {
+    submittedAt: serverTimestamp(),
+    submittedByUid,
+  }, { merge: true });
+};
+
+export const resetAndDeleteApplicationRound = async (
+  applications: Array<{ id: string; applicationFilePath: string; photoPath: string }>
+) => {
+  for (const application of applications) {
+    try {
+      await deleteObject(ref(storage, application.applicationFilePath));
+    } catch (error) {
+      console.error("Failed deleting application file", error);
+    }
+    try {
+      await deleteObject(ref(storage, application.photoPath));
+    } catch (error) {
+      console.error("Failed deleting applicant photo", error);
+    }
+    await deleteDoc(doc(getApplicationsCollection(), application.id));
+  }
+
+  try {
+    await deleteDoc(getRoundMetaRef());
+  } catch (error) {
+    console.error("Failed deleting application round metadata", error);
+  }
+};

--- a/src/firebase/api/applications.ts
+++ b/src/firebase/api/applications.ts
@@ -53,8 +53,9 @@ type QueueTemplateTestEmailPayload = {
 
 const uploadApplicationFile = async (file: File, applicantEmail: string, fileTag: string) => {
   const extension = getExtension(file.name);
+  const extensionSuffix = extension ? `.${extension}` : "";
   const safeEmail = applicantEmail.replace(/[^a-zA-Z0-9._-]/g, "_").toLowerCase();
-  const path = `applications/${env}/${Date.now()}-${safeEmail}-${fileTag}.${extension}`;
+  const path = `applications/${env}/${Date.now()}-${safeEmail}-${fileTag}${extensionSuffix}`;
   const storageRef = ref(storage, path);
 
   await uploadBytes(storageRef, file, {

--- a/src/firebase/api/applications.ts
+++ b/src/firebase/api/applications.ts
@@ -176,7 +176,7 @@ export const queueRejectedApplicationEmails = async (rejections: QueueRejectedEm
 export const updateApplicationEmailDeliveryStatuses = async (
   updates: Array<{
     id: string;
-    emailDeliveryStatus?: "pending" | "success" | "failed";
+    emailDeliveryStatus: "pending" | "success" | "failed";
   }>
 ) => {
   if (!updates.length) return;
@@ -184,8 +184,9 @@ export const updateApplicationEmailDeliveryStatuses = async (
   const batch = writeBatch(db);
   updates.forEach((update) => {
     const docRef = doc(getApplicationsCollection(), update.id);
-    const payload: Record<string, string> = {};
-    if (update.emailDeliveryStatus) payload.emailDeliveryStatus = update.emailDeliveryStatus;
+    const payload: Record<string, string> = {
+      emailDeliveryStatus: update.emailDeliveryStatus,
+    };
     batch.update(docRef, payload);
   });
 

--- a/src/firebase/api/applications.ts
+++ b/src/firebase/api/applications.ts
@@ -149,6 +149,7 @@ export const queueRejectedApplicationEmails = async (rejections: QueueRejectedEm
   const results = await Promise.allSettled(
     rejections.map((rejection) =>
       addDoc(collectionRef, {
+        applicationId: rejection.id,
         email: rejection.email,
         fullName: rejection.fullName,
         bodyText: rejection.bodyText ?? "",

--- a/src/firebase/api/applications.ts
+++ b/src/firebase/api/applications.ts
@@ -65,20 +65,43 @@ const uploadApplicationFile = async (file: File, applicantEmail: string, fileTag
   return { path };
 };
 
-export const submitApplication = async (payload: SubmitApplicationPayload) => {
-  const uploaded = await uploadApplicationFile(payload.file, payload.email, "application");
-  const uploadedPhoto = await uploadApplicationFile(payload.photoFile, payload.email, "photo");
+const safeDeleteStoragePath = async (path?: string) => {
+  if (!path) return;
+  try {
+    await deleteObject(ref(storage, path));
+  } catch (error) {
+    console.error("Failed deleting partially uploaded file", error);
+  }
+};
 
-  return addDoc(getApplicationsCollection(), {
-    fullName: payload.fullName,
-    email: payload.email,
-    studyline: payload.studyline,
-    comment: payload.comment ?? "",
-    applicationFilePath: uploaded.path,
-    photoPath: uploadedPhoto.path,
-    decision: "pending",
-    createdAt: serverTimestamp(),
-  });
+export const submitApplication = async (payload: SubmitApplicationPayload) => {
+  let uploadedApplicationPath: string | undefined;
+  let uploadedPhotoPath: string | undefined;
+
+  try {
+    const uploaded = await uploadApplicationFile(payload.file, payload.email, "application");
+    uploadedApplicationPath = uploaded.path;
+
+    const uploadedPhoto = await uploadApplicationFile(payload.photoFile, payload.email, "photo");
+    uploadedPhotoPath = uploadedPhoto.path;
+
+    return await addDoc(getApplicationsCollection(), {
+      fullName: payload.fullName,
+      email: payload.email,
+      studyline: payload.studyline,
+      comment: payload.comment ?? "",
+      applicationFilePath: uploadedApplicationPath,
+      photoPath: uploadedPhotoPath,
+      decision: "pending",
+      createdAt: serverTimestamp(),
+    });
+  } catch (error) {
+    await Promise.all([
+      safeDeleteStoragePath(uploadedApplicationPath),
+      safeDeleteStoragePath(uploadedPhotoPath),
+    ]);
+    throw error;
+  }
 };
 
 export const streamApplications = (

--- a/src/firebase/api/authentication.ts
+++ b/src/firebase/api/authentication.ts
@@ -74,6 +74,8 @@ export interface UserProfile {
 type InviteUserOptions = {
   bodyText?: string;
   fullName?: string;
+  applicationId?: string;
+  applicationEnv?: string;
 };
 
 // Create an account for a new user
@@ -148,10 +150,14 @@ export const streamInvitedUsers = (observer: Observer<QuerySnapshot>) => {
 export const inviteUser = (email: string, options?: InviteUserOptions): Promise<void> => {
   const bodyText = options?.bodyText?.trim();
   const fullName = options?.fullName?.trim();
+  const applicationId = options?.applicationId?.trim();
+  const applicationEnv = options?.applicationEnv?.trim();
   return setDoc(doc(db, 'invites', email), {
     registered: false,
     ...(bodyText ? { bodyText } : {}),
     ...(fullName ? { fullName } : {}),
+    ...(applicationId ? { applicationId } : {}),
+    ...(applicationEnv ? { applicationEnv } : {}),
   });
 };
 

--- a/src/firebase/api/authentication.ts
+++ b/src/firebase/api/authentication.ts
@@ -71,6 +71,11 @@ export interface UserProfile {
   photoUrl: string;
 }
 
+type InviteUserOptions = {
+  bodyText?: string;
+  fullName?: string;
+};
+
 // Create an account for a new user
 export const createAccount = async (form: FormData): Promise<User> => {
   const userCredential: UserCredential = await createUserWithEmailAndPassword(auth, form.email, form.password);
@@ -140,8 +145,14 @@ export const streamInvitedUsers = (observer: Observer<QuerySnapshot>) => {
   });
 };
 // Invite a user by email
-export const inviteUser = (email: string): Promise<void> => {
-  return setDoc(doc(db, 'invites', email), { registered: false });
+export const inviteUser = (email: string, options?: InviteUserOptions): Promise<void> => {
+  const bodyText = options?.bodyText?.trim();
+  const fullName = options?.fullName?.trim();
+  return setDoc(doc(db, 'invites', email), {
+    registered: false,
+    ...(bodyText ? { bodyText } : {}),
+    ...(fullName ? { fullName } : {}),
+  });
 };
 
 // Delete an invite by its ID

--- a/src/hooks/useApplications.ts
+++ b/src/hooks/useApplications.ts
@@ -3,15 +3,17 @@ import { DocumentData, DocumentSnapshot, QuerySnapshot, Timestamp } from "fireba
 import { useEffect, useMemo, useState } from "react";
 import {
   queueTemplateTestEmail,
+  QueueEmailResult,
   queueRejectedApplicationEmails,
   resetAndDeleteApplicationRound,
   streamApplicationRoundMeta,
   streamApplications,
   submitApplication,
   submitApplicationRound,
+  updateApplicationEmailDeliveryStatuses,
   updateApplicationDecision,
 } from "../firebase/api/applications";
-import { ApplicationDecision, IntakeApplication } from "../types/types-file";
+import { ApplicationDecision, EmailDeliveryStatus, IntakeApplication } from "../types/types-file";
 
 type ApplicationsState = {
   loading: boolean;
@@ -39,6 +41,7 @@ export default function useApplications() {
             applicationFilePath: data.applicationFilePath,
             photoPath: data.photoPath,
             decision: (data.decision ?? "pending") as ApplicationDecision,
+            emailDeliveryStatus: (data.emailDeliveryStatus ?? "pending") as EmailDeliveryStatus,
             createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : undefined,
           };
         });
@@ -91,18 +94,30 @@ export default function useApplications() {
   };
 
   const queueRejectedEmails = async (
-    rejections: Array<{ email: string; fullName: string }>,
+    rejections: Array<{ id: string; email: string; fullName: string }>,
     bodyText?: string
-  ) => {
-    if (!rejections.length) return;
+  ): Promise<QueueEmailResult> => {
+    if (!rejections.length) {
+      return { successful: [], failed: [] };
+    }
 
-    await queueRejectedApplicationEmails(
+    return queueRejectedApplicationEmails(
       rejections.map((rejection) => ({
+        id: rejection.id,
         email: rejection.email,
         fullName: rejection.fullName,
         bodyText,
       }))
     );
+  };
+
+  const setEmailDeliveryStatuses = async (
+    updates: Array<{
+      id: string;
+      emailDeliveryStatus?: "pending" | "success" | "failed";
+    }>
+  ) => {
+    await updateApplicationEmailDeliveryStatuses(updates);
   };
 
   const sendTemplateTestEmail = async (payload: {
@@ -142,6 +157,7 @@ export default function useApplications() {
     setDecision,
     submitRound,
     queueRejectedEmails,
+    setEmailDeliveryStatuses,
     sendTemplateTestEmail,
     deleteRound,
   };

--- a/src/hooks/useApplications.ts
+++ b/src/hooks/useApplications.ts
@@ -114,7 +114,7 @@ export default function useApplications() {
   const setEmailDeliveryStatuses = async (
     updates: Array<{
       id: string;
-      emailDeliveryStatus?: "pending" | "success" | "failed";
+      emailDeliveryStatus: "pending" | "success" | "failed";
     }>
   ) => {
     await updateApplicationEmailDeliveryStatuses(updates);

--- a/src/hooks/useApplications.ts
+++ b/src/hooks/useApplications.ts
@@ -2,6 +2,8 @@ import { message } from "antd";
 import { DocumentData, DocumentSnapshot, QuerySnapshot, Timestamp } from "firebase/firestore";
 import { useEffect, useMemo, useState } from "react";
 import {
+  queueTemplateTestEmail,
+  queueRejectedApplicationEmails,
   resetAndDeleteApplicationRound,
   streamApplicationRoundMeta,
   streamApplications,
@@ -88,6 +90,31 @@ export default function useApplications() {
     message.success("Application round submitted.");
   };
 
+  const queueRejectedEmails = async (
+    rejections: Array<{ email: string; fullName: string }>,
+    bodyText?: string
+  ) => {
+    if (!rejections.length) return;
+
+    await queueRejectedApplicationEmails(
+      rejections.map((rejection) => ({
+        email: rejection.email,
+        fullName: rejection.fullName,
+        bodyText,
+      }))
+    );
+  };
+
+  const sendTemplateTestEmail = async (payload: {
+    templateType: "invite" | "rejection";
+    email: string;
+    fullName: string;
+    bodyText?: string;
+  }) => {
+    await queueTemplateTestEmail(payload);
+    message.success("Test email has been sent.");
+  };
+
   const deleteRound = async () => {
     await resetAndDeleteApplicationRound(
       state.applications.map((application) => ({
@@ -114,6 +141,8 @@ export default function useApplications() {
     submitNewApplication,
     setDecision,
     submitRound,
+    queueRejectedEmails,
+    sendTemplateTestEmail,
     deleteRound,
   };
 }

--- a/src/hooks/useApplications.ts
+++ b/src/hooks/useApplications.ts
@@ -1,0 +1,119 @@
+import { message } from "antd";
+import { DocumentData, DocumentSnapshot, QuerySnapshot, Timestamp } from "firebase/firestore";
+import { useEffect, useMemo, useState } from "react";
+import {
+  resetAndDeleteApplicationRound,
+  streamApplicationRoundMeta,
+  streamApplications,
+  submitApplication,
+  submitApplicationRound,
+  updateApplicationDecision,
+} from "../firebase/api/applications";
+import { ApplicationDecision, IntakeApplication } from "../types/types-file";
+
+type ApplicationsState = {
+  loading: boolean;
+  applications: IntakeApplication[];
+  submittedAt?: Date;
+};
+
+export default function useApplications() {
+  const [state, setState] = useState<ApplicationsState>({
+    loading: true,
+    applications: [],
+  });
+
+  useEffect(() => {
+    const unsubscribeApplications = streamApplications(
+      (snapshot: QuerySnapshot<DocumentData>) => {
+        const applications: IntakeApplication[] = snapshot.docs.map((doc) => {
+          const data = doc.data();
+          return {
+            id: doc.id,
+            fullName: data.fullName,
+            email: data.email,
+            studyline: data.studyline,
+            comment: data.comment,
+            applicationFilePath: data.applicationFilePath,
+            photoPath: data.photoPath,
+            decision: (data.decision ?? "pending") as ApplicationDecision,
+            createdAt: data.createdAt instanceof Timestamp ? data.createdAt.toDate() : undefined,
+          };
+        });
+
+        setState((prev) => ({ ...prev, applications, loading: false }));
+      },
+      (error) => {
+        message.error(`Failed to load applications: ${error.message}`);
+        setState((prev) => ({ ...prev, loading: false }));
+      }
+    );
+
+    const unsubscribeMeta = streamApplicationRoundMeta(
+      (snapshot: DocumentSnapshot<DocumentData>) => {
+        const data = snapshot.data();
+        const submittedAt =
+          data?.submittedAt instanceof Timestamp ? data.submittedAt.toDate() : undefined;
+        setState((prev) => ({ ...prev, submittedAt }));
+      },
+      (error) => {
+        message.error(`Failed to load application round metadata: ${error.message}`);
+      }
+    );
+
+    return () => {
+      unsubscribeApplications();
+      unsubscribeMeta();
+    };
+  }, []);
+
+  const submitNewApplication = async (payload: {
+    fullName: string;
+    email: string;
+    studyline: string;
+    comment: string;
+    file: File;
+    photoFile: File;
+  }) => {
+    await submitApplication(payload);
+    message.success("Application submitted successfully.");
+  };
+
+  const setDecision = async (id: string, decision: "maybe" | "accept" | "reject") => {
+    await updateApplicationDecision(id, decision);
+  };
+
+  const submitRound = async (submittedByUid: string) => {
+    await submitApplicationRound(submittedByUid);
+    message.success("Application round submitted.");
+  };
+
+  const deleteRound = async () => {
+    await resetAndDeleteApplicationRound(
+      state.applications.map((application) => ({
+        id: application.id,
+        applicationFilePath: application.applicationFilePath,
+        photoPath: application.photoPath,
+      }))
+    );
+    message.success("Application round deleted.");
+  };
+
+  const grouped = useMemo(() => {
+    return {
+      pending: state.applications.filter((a) => a.decision === "pending"),
+      maybe: state.applications.filter((a) => a.decision === "maybe"),
+      accept: state.applications.filter((a) => a.decision === "accept"),
+      reject: state.applications.filter((a) => a.decision === "reject"),
+    };
+  }, [state.applications]);
+
+  return {
+    applicationsState: state,
+    grouped,
+    submitNewApplication,
+    setDecision,
+    submitRound,
+    deleteRound,
+  };
+}

--- a/src/hooks/useTenders.ts
+++ b/src/hooks/useTenders.ts
@@ -121,6 +121,32 @@ const useTenders = () => {
       });
   };
 
+  const addInvites = (emails: string[]) => {
+    return Promise.allSettled(
+      emails.map((email) =>
+        inviteUser(email).catch((error) => {
+          throw { email, error };
+        })
+      )
+    ).then((inviteResults) => {
+      const failedInvites = inviteResults.filter((result) => result.status === "rejected");
+      const successfulInvites = inviteResults.filter((result) => result.status === "fulfilled");
+
+      if (failedInvites.length) {
+        failedInvites.forEach((result) => {
+          if (result.status === "rejected") {
+            const reason = result.reason as { email?: string; error?: { message?: string } };
+            message.error(`Failed to invite ${reason.email}: ${reason.error?.message}`);
+          }
+        });
+      } else {
+        message.success(
+          `Invited ${successfulInvites.length} accepted applicant${successfulInvites.length === 1 ? "" : "s"}.`
+        );
+      }
+    });
+  };
+
   // Remove invite
   const removeInvite = (row: string) => {
     return deleteInvite({id: row})
@@ -182,6 +208,7 @@ const useTenders = () => {
     tenderState,
     invitedTenders,
     addInvite,
+    addInvites,
     removeInvite,
     updateTender,
     deleteTender,

--- a/src/hooks/useTenders.ts
+++ b/src/hooks/useTenders.ts
@@ -109,8 +109,8 @@ const useTenders = () => {
   }, []);
 
   // Add invite
-  const addInvite = (email: string) => {
-    return inviteUser(email)
+  const addInvite = (email: string, bodyText?: string, fullName?: string) => {
+    return inviteUser(email, { bodyText, fullName })
       .then((response) => {
         message.success("Invite sent successfully!");
         return response; // Return the response from the inviteUser function
@@ -121,11 +121,11 @@ const useTenders = () => {
       });
   };
 
-  const addInvites = (emails: string[]) => {
+  const addInvites = (recipients: Array<{ email: string; fullName?: string }>, bodyText?: string) => {
     return Promise.allSettled(
-      emails.map((email) =>
-        inviteUser(email).catch((error) => {
-          throw { email, error };
+      recipients.map((recipient) =>
+        inviteUser(recipient.email, { bodyText, fullName: recipient.fullName }).catch((error) => {
+          throw { email: recipient.email, error };
         })
       )
     ).then((inviteResults) => {

--- a/src/hooks/useTenders.ts
+++ b/src/hooks/useTenders.ts
@@ -21,6 +21,11 @@ type TenderState = {
   studylines?: StudyLine[]; // Optional property for study lines
 };
 
+type AddInvitesResult = {
+  successful: string[];
+  failed: Array<{ id: string; email: string; error: unknown }>;
+};
+
 const useTenders = () => {
   const [tenderState, setTenderState] = useState<TenderState>({
     loading: false,
@@ -121,29 +126,39 @@ const useTenders = () => {
       });
   };
 
-  const addInvites = (recipients: Array<{ email: string; fullName?: string }>, bodyText?: string) => {
+  const addInvites = (
+    recipients: Array<{ id: string; email: string; fullName?: string }>,
+    bodyText?: string
+  ): Promise<AddInvitesResult> => {
     return Promise.allSettled(
       recipients.map((recipient) =>
-        inviteUser(recipient.email, { bodyText, fullName: recipient.fullName }).catch((error) => {
-          throw { email: recipient.email, error };
-        })
+        inviteUser(recipient.email, { bodyText, fullName: recipient.fullName })
       )
     ).then((inviteResults) => {
-      const failedInvites = inviteResults.filter((result) => result.status === "rejected");
-      const successfulInvites = inviteResults.filter((result) => result.status === "fulfilled");
+      const successful: string[] = [];
+      const failed: Array<{ id: string; email: string; error: unknown }> = [];
 
-      if (failedInvites.length) {
-        failedInvites.forEach((result) => {
-          if (result.status === "rejected") {
-            const reason = result.reason as { email?: string; error?: { message?: string } };
-            message.error(`Failed to invite ${reason.email}: ${reason.error?.message}`);
-          }
+      inviteResults.forEach((result, index) => {
+        const recipient = recipients[index];
+        if (result.status === "fulfilled") {
+          successful.push(recipient.id);
+        } else {
+          failed.push({ id: recipient.id, email: recipient.email, error: result.reason });
+        }
+      });
+
+      if (failed.length) {
+        failed.forEach((entry) => {
+          const reason = entry.error as { message?: string };
+          message.error(`Failed to invite ${entry.email}: ${reason?.message}`);
         });
       } else {
         message.success(
-          `Invited ${successfulInvites.length} accepted applicant${successfulInvites.length === 1 ? "" : "s"}.`
+          `Invited ${successful.length} accepted applicant${successful.length === 1 ? "" : "s"}.`
         );
       }
+
+      return { successful, failed };
     });
   };
 

--- a/src/hooks/useTenders.ts
+++ b/src/hooks/useTenders.ts
@@ -27,6 +27,7 @@ type AddInvitesResult = {
 };
 
 const useTenders = () => {
+  const appEnv = import.meta.env.VITE_APP_ENV as string;
   const [tenderState, setTenderState] = useState<TenderState>({
     loading: false,
     isLoaded: false,
@@ -132,7 +133,12 @@ const useTenders = () => {
   ): Promise<AddInvitesResult> => {
     return Promise.allSettled(
       recipients.map((recipient) =>
-        inviteUser(recipient.email, { bodyText, fullName: recipient.fullName })
+        inviteUser(recipient.email, {
+          bodyText,
+          fullName: recipient.fullName,
+          applicationId: recipient.id,
+          applicationEnv: appEnv,
+        })
       )
     ).then((inviteResults) => {
       const successful: string[] = [];

--- a/src/index.css
+++ b/src/index.css
@@ -114,3 +114,33 @@ button:focus-visible {
   background: #e5e7eb;
   color: #111827;
 }
+
+.ant-btn.ant-btn-primary.home-apply-button {
+  margin-top: 16px;
+  min-height: 46px;
+  padding: 9px 34px;
+  border-radius: 999px;
+  border: 1px solid #b7ae00;
+  background: #d7ce00;
+  color: #1f1f1f;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.1px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.ant-btn.ant-btn-primary.home-apply-button:hover,
+.ant-btn.ant-btn-primary.home-apply-button:focus,
+.ant-btn.ant-btn-primary.home-apply-button:focus-visible {
+  background: #e4dc2c;
+  color: #161616;
+  border-color: #a79e00;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.16);
+}
+
+.ant-btn.ant-btn-primary.home-apply-button:active {
+  transform: translateY(0);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.14);
+}

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -34,6 +34,7 @@ export default function ApplyPage() {
 
   const handleSubmit = async (values: any) => {
     if (!fileList.length || !photoFileList.length) {
+      message.error("Please upload both the application file and a recent photo.");
       return;
     }
 

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -1,0 +1,191 @@
+import { Button, Card, Form, Input, Layout, message, Typography, Upload } from "antd";
+import { UploadOutlined } from "@ant-design/icons";
+import { useMemo, useState } from "react";
+import { submitApplication } from "../firebase/api/applications";
+import HeaderBar from "../components/HomePage/HeaderBar";
+import heroImage from "../assets/images/hero.jpg";
+import StudyLinePicker from "./members/StudyLinePicker";
+import useSettings from "../hooks/useSettings";
+import { Loading } from "../components/Loading";
+import { formatWindowDate, getSignupWindowState } from "../utils/signupWindow";
+
+const { Content } = Layout;
+const { Title, Paragraph } = Typography;
+
+export default function ApplyPage() {
+  const [form] = Form.useForm();
+  const [fileList, setFileList] = useState<any[]>([]);
+  const [photoFileList, setPhotoFileList] = useState<any[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const { settingsState } = useSettings();
+
+  const signupWindow = useMemo(
+    () =>
+      getSignupWindowState(
+        settingsState.settings.openForSignupsStart,
+        settingsState.settings.openForSignupsEnd
+      ),
+    [settingsState.settings.openForSignupsEnd, settingsState.settings.openForSignupsStart]
+  );
+
+  if (settingsState.loading) {
+    return <Loading centerOverlay />;
+  }
+
+  const handleSubmit = async (values: any) => {
+    if (!fileList.length || !photoFileList.length) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await submitApplication({
+        fullName: values.fullName,
+        email: values.email,
+        studyline: values.studyline,
+        comment: values.comment,
+        file: fileList[0].originFileObj as File,
+        photoFile: photoFileList[0].originFileObj as File,
+      });
+      message.success("Application submitted successfully.");
+      form.resetFields();
+      setFileList([]);
+      setPhotoFileList([]);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Layout style={{ minHeight: "50vh", background: "#f5f5f5" }}>
+      <HeaderBar />
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          height: "36vh",
+          minHeight: 220,
+          backgroundImage: `url(${heroImage})`,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          overflow: "hidden",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backgroundColor: "rgba(0, 0, 0, 0.45)",
+          }}
+        />
+      </div>
+      <Content style={{ display: "flex", justifyContent: "center", alignItems: "flex-start", padding: "0 16px 56px" }}>
+        <Card
+          style={{
+            width: "100%",
+            maxWidth: 760,
+            marginTop: -170,
+            borderRadius: 16,
+            boxShadow: "0 18px 48px rgba(0, 0, 0, 0.22)",
+            position: "relative",
+            zIndex: 1,
+          }}
+          styles={{ body: { padding: "28px 28px 24px" } }}
+        >
+          {signupWindow.isOpen ? (
+            <>
+              <Title level={2}>Apply to ScrollBar</Title>
+              <Paragraph>
+                Fill out the form below and upload your application file. You will be contacted by the board after review.
+              </Paragraph>
+
+              <Form form={form} layout="vertical" onFinish={handleSubmit}>
+                <Form.Item label="Full name" name="fullName" rules={[{ required: true, message: "Please enter your name" }]}>
+                  <Input />
+                </Form.Item>
+
+                <Form.Item
+                  label="Email"
+                  name="email"
+                  rules={[
+                    { required: true, type: "email", message: "Please enter a valid email" },
+                    {
+                      validator: (_, value: string) => {
+                        if (!value || /@itu\.dk$/i.test(value.trim())) {
+                          return Promise.resolve();
+                        }
+                        return Promise.reject(new Error("Please use your ITU email address"));
+                      },
+                    },
+                  ]}
+                >
+                  <Input />
+                </Form.Item>
+
+                <Form.Item label="Study line" name="studyline" rules={[{ required: true, message: "Please select your study line" }]}>
+                  <StudyLinePicker
+                    fontSize={14}
+                    filterStudyLine={(studyLine) => studyLine.name.toLowerCase() !== "legacy"}
+                  />
+                </Form.Item>
+
+                <Form.Item
+                  label="Application file"
+                  required
+                  validateStatus={!fileList.length ? "error" : "success"}
+                  help={!fileList.length ? "Please upload one file" : undefined}
+                >
+                  <Upload
+                    fileList={fileList}
+                    maxCount={1}
+                    beforeUpload={() => false}
+                    onChange={(info) => setFileList(info.fileList)}
+                  >
+                    <Button icon={<UploadOutlined />}>Select file</Button>
+                  </Upload>
+                </Form.Item>
+
+                <Form.Item
+                  label="Upload a recent picture of yourself (We want to see your face! Maybe we remember you)"
+                  required
+                  validateStatus={!photoFileList.length ? "error" : "success"}
+                  help={!photoFileList.length ? "Please upload one file" : undefined}
+                >
+                  <Upload
+                    fileList={photoFileList}
+                    maxCount={1}
+                    beforeUpload={() => false}
+                    onChange={(info) => setPhotoFileList(info.fileList)}
+                  >
+                    <Button icon={<UploadOutlined />}>Select file</Button>
+                  </Upload>
+                </Form.Item>
+
+                <Form.Item label="Any other comments?" name="comment">
+                  <Input.TextArea rows={6} />
+                </Form.Item>
+
+                <Button type="primary" htmlType="submit" loading={submitting}>
+                  Submit application
+                </Button>
+              </Form>
+            </>
+          ) : (
+            <div style={{ textAlign: "center", padding: "20px 8px" }}>
+              <Title level={2} style={{ marginBottom: 12 }}>
+                The application round is closed
+              </Title>
+              <Paragraph style={{ fontSize: 16, marginBottom: 8 }}>
+                Applications are currently closed. We take in applications at the beginning of each semester.
+                Please check back during the next application window.
+              </Paragraph>
+              <Button type="primary" href="/" style={{ marginTop: 16 }}>
+                Back to homepage
+              </Button>
+            </div>
+          )}
+        </Card>
+      </Content>
+    </Layout>
+  );
+}

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -51,6 +51,8 @@ export default function ApplyPage() {
       form.resetFields();
       setFileList([]);
       setPhotoFileList([]);
+    } catch (error: any) {
+      message.error(error?.message || "Failed to submit application. Nothing was saved, please try again.");
     } finally {
       setSubmitting(false);
     }

--- a/src/pages/ApplyPage.tsx
+++ b/src/pages/ApplyPage.tsx
@@ -7,7 +7,7 @@ import heroImage from "../assets/images/hero.jpg";
 import StudyLinePicker from "./members/StudyLinePicker";
 import useSettings from "../hooks/useSettings";
 import { Loading } from "../components/Loading";
-import { formatWindowDate, getSignupWindowState } from "../utils/signupWindow";
+import { getSignupWindowState } from "../utils/signupWindow";
 
 const { Content } = Layout;
 const { Title, Paragraph } = Typography;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,6 +14,7 @@ import {useNextEvent}  from '../hooks/useEvents'
 import { useLocation } from 'react-router-dom'
 import { UserList, TenderWithRole } from '../components/UserList'
 import { useWindowSize } from '../hooks/useWindowSize'
+import { getSignupWindowState } from '../utils/signupWindow'
 
 export default function HomePage() {
   const { settingsState } = useSettings();
@@ -42,6 +43,13 @@ export default function HomePage() {
       el.scrollIntoView();
     }
   }, [targetId, settingsState.loading]);
+
+  const signupsOpen = useMemo(() => {
+    return getSignupWindowState(
+      settingsState.settings.openForSignupsStart,
+      settingsState.settings.openForSignupsEnd
+    ).isOpen;
+  }, [settingsState.settings.openForSignupsEnd, settingsState.settings.openForSignupsStart]);
 
   if (settingsState.loading || boardRolesState.loading) {
     return <Loading centerOverlay={true} />;
@@ -133,7 +141,7 @@ export default function HomePage() {
           </Col>
         </Row>
 
-        {settingsState.settings.openForSignups && (
+        {signupsOpen && (
           <>
             <Divider />
 
@@ -165,8 +173,9 @@ export default function HomePage() {
                 <Button
                   type="primary"
                   size="large"
-                  href={settingsState.settings.joinScrollBarLink}
+                  href={'/apply'}
                   target="_blank"
+                  className="home-apply-button"
                 >
                   Apply now!
                 </Button>

--- a/src/pages/admin/ApplicationsReviewPage.tsx
+++ b/src/pages/admin/ApplicationsReviewPage.tsx
@@ -394,7 +394,7 @@ export default function ApplicationsReviewPage() {
                     ? "No applications to submit"
                     : canSubmit
                     ? "Submit the round and invite accepted applicants"
-                    : "All applications must be classified and at least one must be accepted to submit"
+                    : "All applications must be classified as accepted or rejected to submit"
                   }
                   loading={submittingRound}
                 >

--- a/src/pages/admin/ApplicationsReviewPage.tsx
+++ b/src/pages/admin/ApplicationsReviewPage.tsx
@@ -73,7 +73,7 @@ export default function ApplicationsReviewPage() {
   const renderDeliveryIcon = (status: "pending" | "success" | "failed") => {
     if (status === "success") {
       return (
-        <Tooltip title="Email queued/sent successfully.">
+        <Tooltip title="Email was sent successfully by mail service.">
           <CheckCircleOutlined style={{ color: "#52c41a", fontSize: 18 }} />
         </Tooltip>
       );
@@ -87,7 +87,7 @@ export default function ApplicationsReviewPage() {
     }
     if (status === "pending") {
       return (
-        <Tooltip title="Email has not been processed yet.">
+        <Tooltip title="Email is queued and awaiting mail service processing.">
           <ClockCircleOutlined style={{ color: "#faad14", fontSize: 18 }} />
         </Tooltip>
       );
@@ -441,13 +441,13 @@ export default function ApplicationsReviewPage() {
                       ...grouped.accept.map((application) => ({
                         id: application.id,
                         emailDeliveryStatus: inviteResult.successful.includes(application.id)
-                          ? ("success" as const)
+                          ? ("pending" as const)
                           : ("failed" as const),
                       })),
                       ...grouped.reject.map((application) => ({
                         id: application.id,
                         emailDeliveryStatus: rejectResult.successful.includes(application.id)
-                          ? ("success" as const)
+                          ? ("pending" as const)
                           : ("failed" as const),
                       })),
                     ]);
@@ -455,8 +455,10 @@ export default function ApplicationsReviewPage() {
                     const failedTotal = inviteResult.failed.length + rejectResult.failed.length;
                     if (failedTotal) {
                       message.warning(
-                        `${failedTotal} email${failedTotal === 1 ? "" : "s"} failed. You can retry failed entries.`
+                        `${failedTotal} email${failedTotal === 1 ? "" : "s"} could not be queued. You can retry failed entries.`
                       );
+                    } else {
+                      message.success("Emails queued. Delivery status will update automatically when mail service completes.");
                     }
 
                     await submitRound(currentUser.uid);
@@ -522,13 +524,13 @@ export default function ApplicationsReviewPage() {
                         ...failedInvites.map((application) => ({
                           id: application.id,
                           emailDeliveryStatus: inviteRetryResult.successful.includes(application.id)
-                            ? ("success" as const)
+                            ? ("pending" as const)
                             : ("failed" as const),
                         })),
                         ...failedRejections.map((application) => ({
                           id: application.id,
                           emailDeliveryStatus: rejectRetryResult.successful.includes(application.id)
-                            ? ("success" as const)
+                            ? ("pending" as const)
                             : ("failed" as const),
                         })),
                       ]);
@@ -536,10 +538,10 @@ export default function ApplicationsReviewPage() {
                       const failedTotal = inviteRetryResult.failed.length + rejectRetryResult.failed.length;
                       if (failedTotal) {
                         message.warning(
-                          `${failedTotal} email${failedTotal === 1 ? "" : "s"} still failed after retry.`
+                          `${failedTotal} email${failedTotal === 1 ? "" : "s"} still could not be queued after retry.`
                         );
                       } else {
-                        message.success("All previously failed email entries were sent successfully.");
+                        message.success("All previously failed email entries are queued. Delivery status will update automatically.");
                       }
                     } finally {
                       setRetryingFailed(false);

--- a/src/pages/admin/ApplicationsReviewPage.tsx
+++ b/src/pages/admin/ApplicationsReviewPage.tsx
@@ -1,0 +1,329 @@
+import {
+  Button,
+  Divider,
+  Image,
+  Layout,
+  message,
+  Popconfirm,
+  Space,
+  Table,
+  Tabs,
+  Tag,
+  Tooltip,
+  Typography,
+} from "antd";
+import { Content } from "antd/es/layout/layout";
+import { useEffect, useMemo, useState } from "react";
+import useApplications from "../../hooks/useApplications";
+import useTenders from "../../hooks/useTenders";
+import { IntakeApplication, StudyLine } from "../../types/types-file";
+import { useAuth } from "../../contexts/AuthContext";
+import Loading from "../../components/Loading";
+import { getDownloadURL, ref } from "firebase/storage";
+import { storage } from "../../firebase";
+import { getStudyLines } from "../../firebase/api/authentication";
+import avatarPlaceholder from "../../assets/images/avatar.png";
+
+const { Title, Paragraph } = Typography;
+
+export default function ApplicationsReviewPage() {
+  const { currentUser } = useAuth();
+  const { applicationsState, grouped, setDecision, submitRound, deleteRound } = useApplications();
+  const { addInvites } = useTenders();
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [submittingRound, setSubmittingRound] = useState(false);
+  const [deletingRound, setDeletingRound] = useState(false);
+  const [studyLines, setStudyLines] = useState<StudyLine[]>([]);
+  const [photoUrls, setPhotoUrls] = useState<Record<string, string>>({});
+
+  const isAdmin = !!currentUser?.isAdmin;
+
+  const canSubmit = useMemo(() => {
+    if (!isAdmin || applicationsState.submittedAt) return false;
+    if (!applicationsState.applications.length) return false;
+    return applicationsState.applications.every(
+      (application) => application.decision === "accept" || application.decision === "reject"
+    );
+  }, [applicationsState.applications, applicationsState.submittedAt, isAdmin]);
+
+  useEffect(() => {
+    getStudyLines()
+      .then((response) => {
+        const mapped: StudyLine[] = response.map((doc: unknown) => doc as StudyLine);
+        setStudyLines(mapped);
+      })
+      .catch((error) => {
+        message.error(`Failed to load study lines: ${error.message}`);
+      });
+  }, []);
+
+  useEffect(() => {
+    const missing = applicationsState.applications.filter(
+      (application) => application.photoPath && !photoUrls[application.id]
+    );
+
+    if (!missing.length) return;
+
+    missing.forEach((application) => {
+      getDownloadURL(ref(storage, application.photoPath))
+        .then((url) => {
+          setPhotoUrls((prev) => ({ ...prev, [application.id]: url }));
+        })
+        .catch((error: any) => {
+          message.error(`Failed to load picture: ${error.message}`);
+        });
+    });
+  }, [applicationsState.applications, photoUrls]);
+
+  const columns = [
+    {
+      title: "Name",
+      dataIndex: "fullName",
+      key: "fullName",
+    },
+    {
+      title: "Email",
+      dataIndex: "email",
+      key: "email",
+    },
+    {
+      title: "Study line",
+      dataIndex: "studyline",
+      key: "studyline",
+      render: (value: string) => {
+        const abbreviation = studyLines
+          .find((studyLine) => studyLine.id === value)
+          ?.abbreviation?.toLocaleUpperCase();
+        return abbreviation || value || "-";
+      },
+    },
+    {
+      title: "Comment",
+      dataIndex: "comment",
+      key: "comment",
+      render: (value: string) => (
+        <Tooltip title={value}>
+          <div style={{ maxWidth: 380, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {value}
+          </div>
+        </Tooltip>
+      ),
+    },
+    {
+      title: "Application",
+      dataIndex: "applicationFilePath",
+      key: "applicationFilePath",
+      render: (value: string) => (
+        <Button
+          type="link"
+          style={{ padding: 0 }}
+          onClick={async () => {
+            try {
+              const url = await getDownloadURL(ref(storage, value));
+              window.open(url, "_blank", "noopener,noreferrer");
+            } catch (error: any) {
+              message.error(`Failed to open application file: ${error.message}`);
+            }
+          }}
+        >
+          Open application
+        </Button>
+      ),
+    },
+    {
+      title: "Picture",
+      dataIndex: "photoPath",
+      key: "photoPath",
+      render: (_value: string, record: IntakeApplication) => (
+        <Image
+          src={photoUrls[record.id] || avatarPlaceholder}
+          alt={`${record.fullName} photo`}
+          width={64}
+          height={64}
+          preview={{ mask: "Open" }}
+          style={{ maxWidth: 64, maxHeight: 64, objectFit: "cover", borderRadius: 8 }}
+        />
+      ),
+    },
+    {
+      title: "Decision",
+      dataIndex: "decision",
+      key: "decision",
+      render: (value: string) => {
+        if (value === "accept") return <Tag color="green">Accept</Tag>;
+        if (value === "reject") return <Tag color="red">Reject</Tag>;
+        if (value === "maybe") return <Tag color="gold">Maybe</Tag>;
+        return <Tag>Pending</Tag>;
+      },
+    },
+    ...(isAdmin
+      ? [
+          {
+            title: "Actions",
+            key: "actions",
+            render: (_: unknown, record: IntakeApplication) => (
+              <Space>
+                <Button
+                  size="small"
+                  type={record.decision === "accept" ? "primary" : "default"}
+                  disabled={!!applicationsState.submittedAt}
+                  loading={busyId === `${record.id}-accept`}
+                  onClick={async () => {
+                    setBusyId(`${record.id}-accept`);
+                    try {
+                      await setDecision(record.id, "accept");
+                    } finally {
+                      setBusyId(null);
+                    }
+                  }}
+                >
+                  Accept
+                </Button>
+                <Button
+                  size="small"
+                  type={record.decision === "maybe" ? "primary" : "default"}
+                  disabled={!!applicationsState.submittedAt}
+                  loading={busyId === `${record.id}-maybe`}
+                  onClick={async () => {
+                    setBusyId(`${record.id}-maybe`);
+                    try {
+                      await setDecision(record.id, "maybe");
+                    } finally {
+                      setBusyId(null);
+                    }
+                  }}
+                >
+                  Maybe
+                </Button>
+                <Button
+                  size="small"
+                  danger
+                  type={record.decision === "reject" ? "primary" : "default"}
+                  disabled={!!applicationsState.submittedAt}
+                  loading={busyId === `${record.id}-reject`}
+                  onClick={async () => {
+                    setBusyId(`${record.id}-reject`);
+                    try {
+                      await setDecision(record.id, "reject");
+                    } finally {
+                      setBusyId(null);
+                    }
+                  }}
+                >
+                  Reject
+                </Button>
+              </Space>
+            ),
+          },
+        ]
+      : []),
+  ];
+
+  if (applicationsState.loading) {
+    return <Loading />;
+  }
+
+  return (
+    <Layout style={{ padding: 24 }}>
+      <Title level={3} style={{ margin: 0 }}>
+        Application Review
+      </Title>
+      <Content>
+        <Paragraph>
+          Board members can review all applications. Admins can classify applications and finalize the round.
+        </Paragraph>
+
+        {!!applicationsState.submittedAt && (
+          <Paragraph>
+            <Tag color="blue">Round submitted</Tag>
+            Submitted at {applicationsState.submittedAt.toLocaleString()}
+          </Paragraph>
+        )}
+
+        <Tabs
+          defaultActiveKey="all"
+          items={[
+            {
+              key: "all",
+              label: `All applications (${applicationsState.applications.length})`,
+              children: <Table rowKey="id" dataSource={applicationsState.applications} columns={columns} pagination={false} />,
+            },
+            {
+              key: "pending",
+              label: `Pending (${grouped.pending.length})`,
+              children: <Table rowKey="id" dataSource={grouped.pending} columns={columns} pagination={false} />,
+            },
+            {
+              key: "maybe",
+              label: `Maybe (${grouped.maybe.length})`,
+              children: <Table rowKey="id" dataSource={grouped.maybe} columns={columns} pagination={false} />,
+            },
+            {
+              key: "accept",
+              label: `Accept (${grouped.accept.length})`,
+              children: <Table rowKey="id" dataSource={grouped.accept} columns={columns} pagination={false} />,
+            },
+            {
+              key: "reject",
+              label: `Reject (${grouped.reject.length})`,
+              children: <Table rowKey="id" dataSource={grouped.reject} columns={columns} pagination={false} />,
+            },
+          ]}
+        />
+
+        {isAdmin && (
+          <>
+            <Divider />
+            <Space>
+              <Button
+                type="primary"
+                disabled={!canSubmit}
+                title={
+                  applicationsState.submittedAt
+                  ? "This round has already been submitted"
+                  : !applicationsState.applications.length
+                  ? "No applications to submit"
+                  : canSubmit
+                  ? "Submit the round and invite accepted applicants"
+                  : "All applications must be classified and at least one must be accepted to submit"
+                }
+                loading={submittingRound}
+                onClick={async () => {
+                  if (!currentUser?.uid) return;
+                  setSubmittingRound(true);
+                  try {
+                    await addInvites(grouped.accept.map((application) => application.email));
+                    await submitRound(currentUser.uid);
+                  } finally {
+                    setSubmittingRound(false);
+                  }
+                }}
+              >
+                Submit
+              </Button>
+
+              <Popconfirm
+                title="Delete application round"
+                description="This permanently deletes all applications and uploaded files for this round."
+                okText="Delete"
+                okButtonProps={{ danger: true }}
+                onConfirm={async () => {
+                  setDeletingRound(true);
+                  try {
+                    await deleteRound();
+                  } finally {
+                    setDeletingRound(false);
+                  }
+                }}
+              >
+                <Button danger loading={deletingRound}>
+                  Delete round
+                </Button>
+              </Popconfirm>
+            </Space>
+          </>
+        )}
+      </Content>
+    </Layout>
+  );
+}

--- a/src/pages/admin/ApplicationsReviewPage.tsx
+++ b/src/pages/admin/ApplicationsReviewPage.tsx
@@ -1,4 +1,10 @@
 import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  ClockCircleOutlined,
+  RedoOutlined,
+} from "@ant-design/icons";
+import {
   Button,
   Divider,
   Image,
@@ -29,12 +35,22 @@ const { Title, Paragraph } = Typography;
 
 export default function ApplicationsReviewPage() {
   const { currentUser } = useAuth();
-  const { applicationsState, grouped, setDecision, submitRound, deleteRound, queueRejectedEmails, sendTemplateTestEmail } = useApplications();
+  const {
+    applicationsState,
+    grouped,
+    setDecision,
+    submitRound,
+    deleteRound,
+    queueRejectedEmails,
+    sendTemplateTestEmail,
+    setEmailDeliveryStatuses,
+  } = useApplications();
   const { addInvites } = useTenders();
   const { settingsState } = useSettings();
   const [busyId, setBusyId] = useState<string | null>(null);
   const [submittingRound, setSubmittingRound] = useState(false);
   const [deletingRound, setDeletingRound] = useState(false);
+  const [retryingFailed, setRetryingFailed] = useState(false);
   const [sendingInviteTest, setSendingInviteTest] = useState(false);
   const [sendingRejectionTest, setSendingRejectionTest] = useState(false);
   const [studyLines, setStudyLines] = useState<StudyLine[]>([]);
@@ -49,6 +65,34 @@ export default function ApplicationsReviewPage() {
       (application) => application.decision === "accept" || application.decision === "reject"
     );
   }, [applicationsState.applications, applicationsState.submittedAt, isAdmin]);
+
+  const hasFailedDeliveries = useMemo(() => {
+    return applicationsState.applications.some((application) => application.emailDeliveryStatus === "failed");
+  }, [applicationsState.applications]);
+
+  const renderDeliveryIcon = (status: "pending" | "success" | "failed") => {
+    if (status === "success") {
+      return (
+        <Tooltip title="Email queued/sent successfully.">
+          <CheckCircleOutlined style={{ color: "#52c41a", fontSize: 18 }} />
+        </Tooltip>
+      );
+    }
+    if (status === "failed") {
+      return (
+        <Tooltip title="Email queue/send failed. Admin can retry failed entries.">
+          <CloseCircleOutlined style={{ color: "#ff4d4f", fontSize: 18 }} />
+        </Tooltip>
+      );
+    }
+    if (status === "pending") {
+      return (
+        <Tooltip title="Email has not been processed yet.">
+          <ClockCircleOutlined style={{ color: "#faad14", fontSize: 18 }} />
+        </Tooltip>
+      );
+    }
+  };
 
   useEffect(() => {
     getStudyLines()
@@ -160,7 +204,19 @@ export default function ApplicationsReviewPage() {
         return <Tag>Pending</Tag>;
       },
     },
-    ...(isAdmin
+    ...(applicationsState.submittedAt
+      ? [
+          {
+            title: "Email status",
+            key: "emailStatus",
+            render: (_: unknown, record: IntakeApplication) => {
+              if (record.decision === "accept" || record.decision === "reject") {
+                return renderDeliveryIcon(record.emailDeliveryStatus);
+              }
+            },
+          },
+        ]
+      : isAdmin
       ? [
           {
             title: "Actions",
@@ -364,20 +420,45 @@ export default function ApplicationsReviewPage() {
                   if (!currentUser?.uid) return;
                   setSubmittingRound(true);
                   try {
-                    await addInvites(
+                    const inviteResult = await addInvites(
                       grouped.accept.map((application) => ({
+                        id: application.id,
                         email: application.email,
                         fullName: application.fullName,
                       })),
                       settingsState.settings.inviteEmailBodyText
                     );
-                    await queueRejectedEmails(
+                    const rejectResult = await queueRejectedEmails(
                       grouped.reject.map((application) => ({
+                        id: application.id,
                         email: application.email,
                         fullName: application.fullName,
                       })),
                       settingsState.settings.rejectionEmailBodyText
                     );
+
+                    await setEmailDeliveryStatuses([
+                      ...grouped.accept.map((application) => ({
+                        id: application.id,
+                        emailDeliveryStatus: inviteResult.successful.includes(application.id)
+                          ? ("success" as const)
+                          : ("failed" as const),
+                      })),
+                      ...grouped.reject.map((application) => ({
+                        id: application.id,
+                        emailDeliveryStatus: rejectResult.successful.includes(application.id)
+                          ? ("success" as const)
+                          : ("failed" as const),
+                      })),
+                    ]);
+
+                    const failedTotal = inviteResult.failed.length + rejectResult.failed.length;
+                    if (failedTotal) {
+                      message.warning(
+                        `${failedTotal} email${failedTotal === 1 ? "" : "s"} failed. You can retry failed entries.`
+                      );
+                    }
+
                     await submitRound(currentUser.uid);
                   } finally {
                     setSubmittingRound(false);
@@ -401,6 +482,75 @@ export default function ApplicationsReviewPage() {
                   Submit
                 </Button>
               </Popconfirm>
+
+              {applicationsState.submittedAt && hasFailedDeliveries && (
+                <Popconfirm
+                  title="Retry failed email entries"
+                  description="Retry sending only entries that previously failed?"
+                  okText="Retry"
+                  onConfirm={async () => {
+                    setRetryingFailed(true);
+                    try {
+                      const failedInvites = applicationsState.applications.filter(
+                        (application) =>
+                          application.decision === "accept" && application.emailDeliveryStatus === "failed"
+                      );
+                      const failedRejections = applicationsState.applications.filter(
+                        (application) =>
+                          application.decision === "reject" && application.emailDeliveryStatus === "failed"
+                      );
+
+                      const inviteRetryResult = await addInvites(
+                        failedInvites.map((application) => ({
+                          id: application.id,
+                          email: application.email,
+                          fullName: application.fullName,
+                        })),
+                        settingsState.settings.inviteEmailBodyText
+                      );
+
+                      const rejectRetryResult = await queueRejectedEmails(
+                        failedRejections.map((application) => ({
+                          id: application.id,
+                          email: application.email,
+                          fullName: application.fullName,
+                        })),
+                        settingsState.settings.rejectionEmailBodyText
+                      );
+
+                      await setEmailDeliveryStatuses([
+                        ...failedInvites.map((application) => ({
+                          id: application.id,
+                          emailDeliveryStatus: inviteRetryResult.successful.includes(application.id)
+                            ? ("success" as const)
+                            : ("failed" as const),
+                        })),
+                        ...failedRejections.map((application) => ({
+                          id: application.id,
+                          emailDeliveryStatus: rejectRetryResult.successful.includes(application.id)
+                            ? ("success" as const)
+                            : ("failed" as const),
+                        })),
+                      ]);
+
+                      const failedTotal = inviteRetryResult.failed.length + rejectRetryResult.failed.length;
+                      if (failedTotal) {
+                        message.warning(
+                          `${failedTotal} email${failedTotal === 1 ? "" : "s"} still failed after retry.`
+                        );
+                      } else {
+                        message.success("All previously failed email entries were sent successfully.");
+                      }
+                    } finally {
+                      setRetryingFailed(false);
+                    }
+                  }}
+                >
+                  <Button icon={<RedoOutlined />} loading={retryingFailed}>
+                    Retry failed emails
+                  </Button>
+                </Popconfirm>
+              )}
 
               <Popconfirm
                 title="Delete application round"

--- a/src/pages/admin/ApplicationsReviewPage.tsx
+++ b/src/pages/admin/ApplicationsReviewPage.tsx
@@ -16,6 +16,7 @@ import { Content } from "antd/es/layout/layout";
 import { useEffect, useMemo, useState } from "react";
 import useApplications from "../../hooks/useApplications";
 import useTenders from "../../hooks/useTenders";
+import useSettings from "../../hooks/useSettings";
 import { IntakeApplication, StudyLine } from "../../types/types-file";
 import { useAuth } from "../../contexts/AuthContext";
 import Loading from "../../components/Loading";
@@ -28,11 +29,14 @@ const { Title, Paragraph } = Typography;
 
 export default function ApplicationsReviewPage() {
   const { currentUser } = useAuth();
-  const { applicationsState, grouped, setDecision, submitRound, deleteRound } = useApplications();
+  const { applicationsState, grouped, setDecision, submitRound, deleteRound, queueRejectedEmails, sendTemplateTestEmail } = useApplications();
   const { addInvites } = useTenders();
+  const { settingsState } = useSettings();
   const [busyId, setBusyId] = useState<string | null>(null);
   const [submittingRound, setSubmittingRound] = useState(false);
   const [deletingRound, setDeletingRound] = useState(false);
+  const [sendingInviteTest, setSendingInviteTest] = useState(false);
+  const [sendingRejectionTest, setSendingRejectionTest] = useState(false);
   const [studyLines, setStudyLines] = useState<StudyLine[]>([]);
   const [photoUrls, setPhotoUrls] = useState<Record<string, string>>({});
 
@@ -163,12 +167,12 @@ export default function ApplicationsReviewPage() {
             key: "actions",
             render: (_: unknown, record: IntakeApplication) => (
               <Space>
-                <Button
-                  size="small"
-                  type={record.decision === "accept" ? "primary" : "default"}
+                <Popconfirm
+                  title="Set decision to Accept"
+                  description={`Mark ${record.fullName} as accepted?`}
+                  okText="Accept"
                   disabled={!!applicationsState.submittedAt}
-                  loading={busyId === `${record.id}-accept`}
-                  onClick={async () => {
+                  onConfirm={async () => {
                     setBusyId(`${record.id}-accept`);
                     try {
                       await setDecision(record.id, "accept");
@@ -177,14 +181,21 @@ export default function ApplicationsReviewPage() {
                     }
                   }}
                 >
-                  Accept
-                </Button>
-                <Button
-                  size="small"
-                  type={record.decision === "maybe" ? "primary" : "default"}
+                  <Button
+                    size="small"
+                    type={record.decision === "accept" ? "primary" : "default"}
+                    disabled={!!applicationsState.submittedAt}
+                    loading={busyId === `${record.id}-accept`}
+                  >
+                    Accept
+                  </Button>
+                </Popconfirm>
+                <Popconfirm
+                  title="Set decision to Maybe"
+                  description={`Mark ${record.fullName} as maybe?`}
+                  okText="Set maybe"
                   disabled={!!applicationsState.submittedAt}
-                  loading={busyId === `${record.id}-maybe`}
-                  onClick={async () => {
+                  onConfirm={async () => {
                     setBusyId(`${record.id}-maybe`);
                     try {
                       await setDecision(record.id, "maybe");
@@ -193,15 +204,22 @@ export default function ApplicationsReviewPage() {
                     }
                   }}
                 >
-                  Maybe
-                </Button>
-                <Button
-                  size="small"
-                  danger
-                  type={record.decision === "reject" ? "primary" : "default"}
+                  <Button
+                    size="small"
+                    type={record.decision === "maybe" ? "primary" : "default"}
+                    disabled={!!applicationsState.submittedAt}
+                    loading={busyId === `${record.id}-maybe`}
+                  >
+                    Maybe
+                  </Button>
+                </Popconfirm>
+                <Popconfirm
+                  title="Set decision to Reject"
+                  description={`Mark ${record.fullName} as rejected?`}
+                  okText="Reject"
+                  okButtonProps={{ danger: true }}
                   disabled={!!applicationsState.submittedAt}
-                  loading={busyId === `${record.id}-reject`}
-                  onClick={async () => {
+                  onConfirm={async () => {
                     setBusyId(`${record.id}-reject`);
                     try {
                       await setDecision(record.id, "reject");
@@ -210,8 +228,16 @@ export default function ApplicationsReviewPage() {
                     }
                   }}
                 >
-                  Reject
-                </Button>
+                  <Button
+                    size="small"
+                    danger
+                    type={record.decision === "reject" ? "primary" : "default"}
+                    disabled={!!applicationsState.submittedAt}
+                    loading={busyId === `${record.id}-reject`}
+                  >
+                    Reject
+                  </Button>
+                </Popconfirm>
               </Space>
             ),
           },
@@ -275,32 +301,106 @@ export default function ApplicationsReviewPage() {
           <>
             <Divider />
             <Space>
-              <Button
-                type="primary"
+              <Popconfirm
+                title="Send invite test email"
+                description="Send the invite template to yourself?"
+                okText="Send test"
+                onConfirm={async () => {
+                  if (!currentUser?.email) {
+                    message.error("Your user account has no email configured.");
+                    return;
+                  }
+                  setSendingInviteTest(true);
+                  try {
+                    await sendTemplateTestEmail({
+                      templateType: "invite",
+                      email: currentUser.email,
+                      fullName: currentUser.displayName ?? "ScrollBar Applicant",
+                      bodyText: settingsState.settings.inviteEmailBodyText,
+                    });
+                  } finally {
+                    setSendingInviteTest(false);
+                  }
+                }}
+              >
+                <Button type="default" loading={sendingInviteTest}>
+                  Send Invite Test To Me
+                </Button>
+              </Popconfirm>
+
+              <Popconfirm
+                title="Send rejection test email"
+                description="Send the rejection template to your own email using your name variables?"
+                okText="Send test"
+                onConfirm={async () => {
+                  if (!currentUser?.email) {
+                    message.error("Your user account has no email configured.");
+                    return;
+                  }
+                  setSendingRejectionTest(true);
+                  try {
+                    await sendTemplateTestEmail({
+                      templateType: "rejection",
+                      email: currentUser.email,
+                      fullName: currentUser.displayName ?? "ScrollBar Applicant",
+                      bodyText: settingsState.settings.rejectionEmailBodyText,
+                    });
+                  } finally {
+                    setSendingRejectionTest(false);
+                  }
+                }}
+              >
+                <Button type="default" loading={sendingRejectionTest}>
+                  Send Rejection Test To Me
+                </Button>
+              </Popconfirm>
+
+              <Popconfirm
+                title="Submit application round"
+                description="This will send invite emails to accepted applicants and rejection emails to rejected applicants, then mark the round as submitted. Continue?"
+                okText="Submit"
                 disabled={!canSubmit}
-                title={
-                  applicationsState.submittedAt
-                  ? "This round has already been submitted"
-                  : !applicationsState.applications.length
-                  ? "No applications to submit"
-                  : canSubmit
-                  ? "Submit the round and invite accepted applicants"
-                  : "All applications must be classified and at least one must be accepted to submit"
-                }
-                loading={submittingRound}
-                onClick={async () => {
+                onConfirm={async () => {
                   if (!currentUser?.uid) return;
                   setSubmittingRound(true);
                   try {
-                    await addInvites(grouped.accept.map((application) => application.email));
+                    await addInvites(
+                      grouped.accept.map((application) => ({
+                        email: application.email,
+                        fullName: application.fullName,
+                      })),
+                      settingsState.settings.inviteEmailBodyText
+                    );
+                    await queueRejectedEmails(
+                      grouped.reject.map((application) => ({
+                        email: application.email,
+                        fullName: application.fullName,
+                      })),
+                      settingsState.settings.rejectionEmailBodyText
+                    );
                     await submitRound(currentUser.uid);
                   } finally {
                     setSubmittingRound(false);
                   }
                 }}
               >
-                Submit
-              </Button>
+                <Button
+                  type="primary"
+                  disabled={!canSubmit}
+                  title={
+                    applicationsState.submittedAt
+                    ? "This round has already been submitted"
+                    : !applicationsState.applications.length
+                    ? "No applications to submit"
+                    : canSubmit
+                    ? "Submit the round and invite accepted applicants"
+                    : "All applications must be classified and at least one must be accepted to submit"
+                  }
+                  loading={submittingRound}
+                >
+                  Submit
+                </Button>
+              </Popconfirm>
 
               <Popconfirm
                 title="Delete application round"

--- a/src/pages/admin/ApplicationsReviewPage.tsx
+++ b/src/pages/admin/ApplicationsReviewPage.tsx
@@ -19,7 +19,7 @@ import {
   Typography,
 } from "antd";
 import { Content } from "antd/es/layout/layout";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import useApplications from "../../hooks/useApplications";
 import useTenders from "../../hooks/useTenders";
 import useSettings from "../../hooks/useSettings";
@@ -55,6 +55,7 @@ export default function ApplicationsReviewPage() {
   const [sendingRejectionTest, setSendingRejectionTest] = useState(false);
   const [studyLines, setStudyLines] = useState<StudyLine[]>([]);
   const [photoUrls, setPhotoUrls] = useState<Record<string, string>>({});
+  const requestedPhotoIdsRef = useRef<Set<string>>(new Set());
 
   const isAdmin = !!currentUser?.isAdmin;
 
@@ -106,13 +107,14 @@ export default function ApplicationsReviewPage() {
   }, []);
 
   useEffect(() => {
-    const missing = applicationsState.applications.filter(
-      (application) => application.photoPath && !photoUrls[application.id]
-    );
+    const missing = applicationsState.applications.filter((application) => {
+      return !!application.photoPath && !requestedPhotoIdsRef.current.has(application.id);
+    });
 
     if (!missing.length) return;
 
     missing.forEach((application) => {
+      requestedPhotoIdsRef.current.add(application.id);
       getDownloadURL(ref(storage, application.photoPath))
         .then((url) => {
           setPhotoUrls((prev) => ({ ...prev, [application.id]: url }));
@@ -121,7 +123,7 @@ export default function ApplicationsReviewPage() {
           message.error(`Failed to load picture: ${error.message}`);
         });
     });
-  }, [applicationsState.applications, photoUrls]);
+  }, [applicationsState.applications]);
 
   const columns = [
     {

--- a/src/pages/admin/ApplicationsReviewPage.tsx
+++ b/src/pages/admin/ApplicationsReviewPage.tsx
@@ -206,18 +206,18 @@ export default function ApplicationsReviewPage() {
     },
     ...(applicationsState.submittedAt
       ? [
-          {
-            title: "Email status",
-            key: "emailStatus",
-            render: (_: unknown, record: IntakeApplication) => {
-              if (record.decision === "accept" || record.decision === "reject") {
-                return renderDeliveryIcon(record.emailDeliveryStatus);
-              }
-            },
+        {
+          title: "Email status",
+          key: "emailStatus",
+          render: (_: unknown, record: IntakeApplication) => {
+            if (record.decision === "accept" || record.decision === "reject") {
+              return renderDeliveryIcon(record.emailDeliveryStatus);
+            }
           },
-        ]
+        },
+      ]
       : isAdmin
-      ? [
+        ? [
           {
             title: "Actions",
             key: "actions",
@@ -298,7 +298,7 @@ export default function ApplicationsReviewPage() {
             ),
           },
         ]
-      : []),
+        : []),
   ];
 
   if (applicationsState.loading) {
@@ -472,12 +472,12 @@ export default function ApplicationsReviewPage() {
                   disabled={!canSubmit}
                   title={
                     applicationsState.submittedAt
-                    ? "This round has already been submitted"
-                    : !applicationsState.applications.length
-                    ? "No applications to submit"
-                    : canSubmit
-                    ? "Submit the round and invite accepted applicants"
-                    : "All applications must be classified as accepted or rejected to submit"
+                      ? "This round has already been submitted"
+                      : !applicationsState.applications.length
+                        ? "No applications to submit"
+                        : canSubmit
+                          ? "Submit the round and invite accepted applicants"
+                          : "All applications must be classified as accepted or rejected to submit"
                   }
                   loading={submittingRound}
                 >

--- a/src/pages/admin/GlobalSettingsPage.tsx
+++ b/src/pages/admin/GlobalSettingsPage.tsx
@@ -4,12 +4,13 @@ import { Button, Input, InputRef, message, Switch, Table, TableProps, Upload } f
 import MDEditor from "@uiw/react-md-editor";
 import { Loading } from "../../components/Loading";
 import { useWindowSize } from "../../hooks/useWindowSize";
+import { formatWindowDate, fromDateTimeInputValue, toDateTimeInputValue } from "../../utils/signupWindow";
 
 type Setting = {
   key: string;
   label: string;
   value: string | boolean;
-  inputType?: "text" | "boolean" | "textarea" | "upload";
+  inputType?: "text" | "boolean" | "textarea" | "upload" | "datetime";
 };
 
 const EditableCell = ({
@@ -31,7 +32,7 @@ const EditableCell = ({
   const [uploading, setUploading] = useState(false);
 
   useEffect(() => {
-    setEditValue(value as string);
+    setEditValue(typeof value === "string" ? value : "");
   }, [value]);
 
   useEffect(() => {
@@ -66,6 +67,20 @@ const EditableCell = ({
         </div>
       );
     }
+    if (inputType === "datetime") {
+      return (
+        <Input
+          ref={inputRef}
+          type="datetime-local"
+          value={toDateTimeInputValue(editValue)}
+          onBlur={(event) => {
+            onChange(fromDateTimeInputValue(event.target.value));
+            setEditing(false);
+          }}
+          onChange={(event) => setEditValue(fromDateTimeInputValue(event.target.value))}
+        />
+      );
+    }
     return (
       <Input
         ref={inputRef}
@@ -78,6 +93,24 @@ const EditableCell = ({
       />
     );
   } else {
+    if (inputType === "datetime") {
+      return (
+        <div
+          tabIndex={0}
+          style={{ textWrap: "wrap" }}
+          role="button"
+          onClick={() => setEditing(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              setEditing(true);
+            }
+          }}
+        >
+          {formatWindowDate(value ? new Date(value) : null)}
+        </div>
+      );
+    }
     if (inputType === "textarea") {
       return (
         <div
@@ -187,12 +220,6 @@ const GlobalSettingsPage = () => {
       value: settingsState.settings.getHelpDescription,
     },
     {
-      key: "joinScrollBarLink",
-      inputType: "text",
-      label: "Join ScrollBar link",
-      value: settingsState.settings.joinScrollBarLink,
-    },
-    {
       key: "joinScrollBarTitle",
       inputType: "text",
       label: "Join ScrollBar title",
@@ -205,10 +232,16 @@ const GlobalSettingsPage = () => {
       value: settingsState.settings.joinScrollBarText,
     },
     {
-      key: "openForSignups",
-      inputType: "boolean",
-      label: "Show join ScrollBar section",
-      value: settingsState.settings.openForSignups,
+      key: "openForSignupsStart",
+      inputType: "datetime",
+      label: "Signups open from",
+      value: settingsState.settings.openForSignupsStart || "",
+    },
+    {
+      key: "openForSignupsEnd",
+      inputType: "datetime",
+      label: "Signups open until",
+      value: settingsState.settings.openForSignupsEnd || "",
     },
   ];
 

--- a/src/pages/admin/GlobalSettingsPage.tsx
+++ b/src/pages/admin/GlobalSettingsPage.tsx
@@ -124,7 +124,7 @@ const EditableCell = ({
           }}
         >
           <MDEditor.Markdown
-            source={value}
+            source={value.trim().length > 0 ? value.trim() : "Click to edit"}
             style={{ background: "white", color: "black", textWrap: "wrap" }}
           />
         </div>
@@ -166,7 +166,7 @@ const EditableCell = ({
           }
         }}
       >
-        {value}
+        {value.trim().length > 0 ? value.trim() : "Click to edit"}
       </div>
     );
   }
@@ -230,6 +230,18 @@ const GlobalSettingsPage = () => {
       inputType: "textarea",
       label: "Join ScrollBar text",
       value: settingsState.settings.joinScrollBarText,
+    },
+    {
+      key: "inviteEmailBodyText",
+      inputType: "textarea",
+      label: "Invite email body text",
+      value: settingsState.settings.inviteEmailBodyText || "",
+    },
+    {
+      key: "rejectionEmailBodyText",
+      inputType: "textarea",
+      label: "Rejection email body text",
+      value: settingsState.settings.rejectionEmailBodyText || "",
     },
     {
       key: "openForSignupsStart",

--- a/src/pages/admin/GlobalSettingsPage.tsx
+++ b/src/pages/admin/GlobalSettingsPage.tsx
@@ -29,6 +29,7 @@ const EditableCell = ({
   const [editing, setEditing] = useState(false);
   const inputRef = useRef<InputRef>(null);
   const [editValue, setEditValue] = useState("");
+  const [dateTimeDraft, setDateTimeDraft] = useState("");
   const [uploading, setUploading] = useState(false);
 
   useEffect(() => {
@@ -40,6 +41,12 @@ const EditableCell = ({
       inputRef.current?.focus();
     }
   }, [editing]);
+
+  useEffect(() => {
+    if (inputType === "datetime") {
+      setDateTimeDraft(toDateTimeInputValue(editValue));
+    }
+  }, [editValue, inputType]);
 
   if (typeof value === "boolean") {
     return <Switch checked={value} onChange={onChange} />;
@@ -72,12 +79,17 @@ const EditableCell = ({
         <Input
           ref={inputRef}
           type="datetime-local"
-          value={toDateTimeInputValue(editValue)}
-          onBlur={(event) => {
-            onChange(fromDateTimeInputValue(event.target.value));
+          value={dateTimeDraft}
+          onBlur={() => {
+            onChange(fromDateTimeInputValue(dateTimeDraft));
             setEditing(false);
           }}
-          onChange={(event) => setEditValue(fromDateTimeInputValue(event.target.value))}
+          onChange={(event) => setDateTimeDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.currentTarget.blur();
+            }
+          }}
         />
       );
     }

--- a/src/pages/members/StudyLinePicker.tsx
+++ b/src/pages/members/StudyLinePicker.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import type { MenuProps } from 'antd';
-import { Dropdown, Space, Typography } from 'antd';
+import { Dropdown, Space } from 'antd';
 import { DownOutlined } from '@ant-design/icons';
 
 import { StudyLine } from "../../types/types-file";
@@ -11,9 +11,16 @@ interface StudyLinePickerProps {
   onChange?: (studyLine: string) => void;
   fontSize?: number;
   bold?: boolean;
+  filterStudyLine?: (studyLine: StudyLine) => boolean;
 }
 
-export default function StudyLinePicker({ value, onChange, fontSize = 16, bold = false }: StudyLinePickerProps) {
+export default function StudyLinePicker({
+  value,
+  onChange,
+  fontSize = 16,
+  bold = false,
+  filterStudyLine,
+}: StudyLinePickerProps) {
   const [selectedValue, setSelectedValue] = useState<string | undefined>(value);
   const [studyLines, setStudyLines] = useState<StudyLine[]>([]);
 
@@ -24,6 +31,31 @@ export default function StudyLinePicker({ value, onChange, fontSize = 16, bold =
     });
   }, []);
 
+  useEffect(() => {
+    setSelectedValue(value);
+  }, [value]);
+
+  const visibleStudyLines = useMemo(() => {
+    const filtered = filterStudyLine ? studyLines.filter(filterStudyLine) : studyLines;
+
+    return [...filtered].sort((a, b) => {
+      const prefixA = (a.prefix ?? "").trim();
+      const prefixB = (b.prefix ?? "").trim();
+      const hasPrefixA = prefixA.length > 0;
+      const hasPrefixB = prefixB.length > 0;
+
+      if (hasPrefixA && !hasPrefixB) return -1;
+      if (!hasPrefixA && hasPrefixB) return 1;
+
+      if (hasPrefixA && hasPrefixB) {
+        const byPrefix = prefixA.localeCompare(prefixB, undefined, { sensitivity: "base" });
+        if (byPrefix !== 0) return byPrefix;
+      }
+
+      return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+    });
+  }, [studyLines, filterStudyLine]);
+
   const handleMenuClick: MenuProps['onClick'] = (e) => {
     const selectedStudyLine = e.key;
     setSelectedValue(selectedStudyLine);
@@ -32,12 +64,12 @@ export default function StudyLinePicker({ value, onChange, fontSize = 16, bold =
     }
   };
 
-  const items: MenuProps['items'] = studyLines.map((sl) => ({
+  const items: MenuProps['items'] = visibleStudyLines.map((sl) => ({
     key: sl.id,
     label: sl.prefix ? `${sl.prefix} in ${sl.name}` : sl.name,
   }));
 
-  const selectedStudyLine = studyLines.find(sl => sl.id === selectedValue);
+  const selectedStudyLine = visibleStudyLines.find(sl => sl.id === selectedValue);
   const displayText = (selectedStudyLine?.prefix ? `${selectedStudyLine.prefix} in ` : "") + (selectedStudyLine?.name || "Select study line");
 
   return (
@@ -50,8 +82,12 @@ export default function StudyLinePicker({ value, onChange, fontSize = 16, bold =
       }}
       trigger={['click']}
     >
-      <Typography.Link
+      <button
+        type="button"
         style={{
+          background: "transparent",
+          border: "none",
+          padding: 0,
           fontSize: `${fontSize}px`,
           fontWeight: bold ? "bold" : "normal",
           color: "inherit",
@@ -63,7 +99,7 @@ export default function StudyLinePicker({ value, onChange, fontSize = 16, bold =
           {displayText}
           <DownOutlined />
         </Space>
-      </Typography.Link>
+      </button>
     </Dropdown>
   );
 }

--- a/src/types/types-file.ts
+++ b/src/types/types-file.ts
@@ -49,11 +49,11 @@ export interface Settings {
   homepageDescription: string;
   getHelpTitle: string;
   getHelpDescription: string;
-  joinScrollBarLink: string;
   joinScrollBarText: string;
   joinScrollBarTitle: string;
   minutes: string;
-  openForSignups: boolean;
+  openForSignupsStart?: string;
+  openForSignupsEnd?: string;
 }
 
 export interface SettingsUpdateParams {
@@ -232,4 +232,18 @@ export interface BoardRole {
   assignedUser?: Tender;
   sortingIndex?: number;
   contactEmail?: string;
+}
+
+export type ApplicationDecision = "pending" | "maybe" | "accept" | "reject";
+
+export interface IntakeApplication {
+  id: string;
+  fullName: string;
+  email: string;
+  studyline: string;
+  comment: string;
+  applicationFilePath: string;
+  photoPath: string;
+  decision: ApplicationDecision;
+  createdAt?: Date;
 }

--- a/src/types/types-file.ts
+++ b/src/types/types-file.ts
@@ -51,6 +51,8 @@ export interface Settings {
   getHelpDescription: string;
   joinScrollBarText: string;
   joinScrollBarTitle: string;
+  inviteEmailBodyText?: string;
+  rejectionEmailBodyText?: string;
   minutes: string;
   openForSignupsStart?: string;
   openForSignupsEnd?: string;

--- a/src/types/types-file.ts
+++ b/src/types/types-file.ts
@@ -238,6 +238,8 @@ export interface BoardRole {
 
 export type ApplicationDecision = "pending" | "maybe" | "accept" | "reject";
 
+export type EmailDeliveryStatus = "pending" | "success" | "failed";
+
 export interface IntakeApplication {
   id: string;
   fullName: string;
@@ -247,5 +249,6 @@ export interface IntakeApplication {
   applicationFilePath: string;
   photoPath: string;
   decision: ApplicationDecision;
+  emailDeliveryStatus: EmailDeliveryStatus;
   createdAt?: Date;
 }

--- a/src/utils/signupWindow.ts
+++ b/src/utils/signupWindow.ts
@@ -1,0 +1,60 @@
+export type SignupWindowState = {
+  isOpen: boolean;
+  isConfigured: boolean;
+  start: Date | null;
+  end: Date | null;
+};
+
+const parseDate = (value?: string): Date | null => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+};
+
+export const getSignupWindowState = (
+  startValue?: string,
+  endValue?: string,
+  now = new Date()
+): SignupWindowState => {
+  const start = parseDate(startValue);
+  const end = parseDate(endValue);
+  const isConfigured = !!start && !!end;
+
+  if (!isConfigured) {
+    return {
+      isOpen: false,
+      isConfigured,
+      start,
+      end,
+    };
+  }
+
+  return {
+    isOpen: now >= start && now <= end,
+    isConfigured,
+    start,
+    end,
+  };
+};
+
+export const toDateTimeInputValue = (value?: string): string => {
+  const parsed = parseDate(value);
+  if (!parsed) return "";
+
+  const timezoneOffsetMs = parsed.getTimezoneOffset() * 60000;
+  const localDate = new Date(parsed.getTime() - timezoneOffsetMs);
+  return localDate.toISOString().slice(0, 16);
+};
+
+export const fromDateTimeInputValue = (value: string): string => {
+  if (!value) return "";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return parsed.toISOString();
+};
+
+export const formatWindowDate = (value?: Date | null): string => {
+  if (!value) return "Not set";
+  return value.toLocaleString();
+};


### PR DESCRIPTION
This change allows new members to apply through the website rather than through external form providers (e.g. Microsoft Forms).

This is done by:
- Having the "Apply to ScrollBar" button be an interval rather than a toggle
- Having a form that saves to a specific location in our database
- Having a application review page available for board members where they can view all applications
- Admins can group applicant's into accepted, rejected or maybe
- Once all applications are out of pending/maybe state, admins can submit the decision
- Submitted application round decision automatically sends out rejected/approved emails to applicant's
- Rejected/approved email texts can be configured/changed by admins
- Admins can test sending the email to themselves first to review application form
- Admins can delete all application content by the click of a button after application round is submitted
- When mails are sent successfully by Mailgun, the status updates for users to see