### PR TITLE
Fairer, self-adjusting shift plan generation + reset period

### DIFF
--- a/functions/src/shiftPlanning/GENERATE_SHIFT_PLAN.md
+++ b/functions/src/shiftPlanning/GENERATE_SHIFT_PLAN.md
@@ -1,0 +1,149 @@
+# Shift plan generation
+
+Documents how `generateShiftPlan.ts` turns survey responses into shift assignments. It runs
+once per `ShiftPlanningPeriod` (blocked from re-running once `status === "generated"` — see
+"Reset period" in the admin UI to undo a run and try again).
+
+## Pipeline
+
+Five phases, always in this order. Each phase's counters feed into the ones after it, which is
+why the order matters — see "Why this order" below.
+
+```mermaid
+flowchart TD
+    Start([Generate shift plan]) --> Guard{Period already<br/>generated?}
+    Guard -- yes --> Reject[["failed-precondition:<br/>reset the period first"]]
+    Guard -- no --> P1
+
+    subgraph P1["Phase 1 — Non-mandatory anchors"]
+        direction TB
+        P1a["anchorOnly experienced anchors<br/>leveled-filled first<br/>(no tender fallback, so priority)"]
+        P1b["mixed experienced anchors<br/>fill whatever anchor slots remain"]
+        P1a --> P1b
+    end
+
+    P1 --> P2
+
+    subgraph P2["Phase 2 — New anchors"]
+        direction TB
+        P2a["Each new anchor guaranteed<br/>1 opening + 1 closing anchor shift"]
+        P2b["Restricted to shifts already anchored<br/>by an experienced anchor (Phase 1),<br/>and to shifts on/after the anchor<br/>seminar cutoff date"]
+        P2a --> P2b
+    end
+
+    P2 --> P3
+
+    subgraph P3["Phase 3 — Non-mandatory tenders"]
+        direction TB
+        P3a["Unified pool: all categories<br/>considered together, not opening→<br/>closing→middle in sequence"]
+        P3b["Each round: only people at the<br/>CURRENT MINIMUM total-shift count<br/>are offered a slot"]
+        P3c["Choice between opening/closing?<br/>Steer toward whichever category<br/>they currently have fewer of"]
+        P3d["Capped: perUserTotalCap /<br/>perUserOpeningCap / perUserClosingCap<br/>(dynamic, see below)"]
+        P3a --> P3b --> P3c --> P3d
+    end
+
+    P3 --> P4
+
+    subgraph P4["Phase 4 — Mandatory anchors"]
+        direction TB
+        P4a["Same anchorOnly-first-then-mixed<br/>leveled fill as Phase 1"]
+        P4b["Runs AFTER Phase 3 so it's informed<br/>by the full non-mandatory picture"]
+        P4a --> P4b
+    end
+
+    P4 --> P5
+
+    subgraph P5["Phase 5 — Mandatory tenders"]
+        direction TB
+        P5a["Everyone eligible + available<br/>GUARANTEED a shift — no cap applies"]
+        P5b["Only real decision: WHICH of the<br/>event's own shifts they land on"]
+        P5c["Steered by true-total opening/closing<br/>counters (incl. anchor + mandatory<br/>exposure), spread by current fill<br/>level so one shift isn't overloaded"]
+        P5a --> P5b --> P5c
+    end
+
+    P5 --> Persist[Persist engagements,<br/>period stats, role updates,<br/>pre-generation snapshot]
+    Persist --> Done([Return summary + warnings])
+
+    classDef phase fill:#eef4ff,stroke:#4a6fa5,color:#1a2b4a;
+    class P1,P2,P3,P4,P5 phase;
+```
+
+Every candidate slot in every phase is also checked against the **avoid-shift-with** list
+(`avoidShiftWithUserIds` on the user doc) — two people who shouldn't work together are never
+matched to the same shift, in either direction, in any phase.
+
+## Why this order
+
+- **Mandatory runs after non-mandatory** (Phase 4/5 after Phase 1/2/3): mandatory duty is
+  guaranteed regardless of load, so it doesn't need — and mustn't be blocked by — the total-shift
+  cap. Running it last means mandatory placement can be *informed* by everyone's real workload
+  so far (steer people toward whichever category they're behind on), without that cap ever
+  risking skipping someone who's supposed to be guaranteed a mandatory shift.
+- **`anchorOnly` before mixed anchors** (Phase 1 and 4): an `anchorOnly` member has no tender
+  fallback — their entire workload comes from anchor duty — so they get first access to the
+  shared fair-share cap. A mixed anchor can always fall back to tender shifts if anchor slots
+  run short for them; an `anchorOnly` member can't.
+- **Anchors before tenders within each half** (1 before 3, 4 before 5): anchor commitments count
+  toward the same shared total, so tender fill needs to see them first to correctly deprioritize
+  people who already picked up anchor duty.
+
+## Dynamic caps (no fixed numbers)
+
+Caps scale to this period's own shift-to-member ratio instead of a hardcoded constant — the
+same idea as the "shifts per member" stat already shown in the admin UI:
+
+```
+perUserTotalCap   = ceil(non-mandatory total capacity   / active members)
+perUserOpeningCap = ceil(non-mandatory opening capacity  / active members)
+perUserClosingCap = ceil(non-mandatory closing capacity  / active members)
+```
+
+Mandatory capacity is excluded from these sums on purpose — mandatory duty is a separate,
+guaranteed layer on top, not something these caps are meant to bound.
+
+**Mandatory is never capped, anywhere, including anchors.** `perUserTotalCap`/`perUserOpeningCap`/
+`perUserClosingCap` gate Phase 1 (non-mandatory anchors) and Phase 3 (non-mandatory tenders) as
+hard blocks. Phase 4 (mandatory anchors) and Phase 5 (mandatory tenders) never check any of them —
+mandatory is treated as an add-on that fills in on top of whatever non-mandatory scheduling already
+produced, guaranteed regardless of load. Both mandatory phases still *steer* toward whichever
+category someone's currently lower on (true-total counters), they just never refuse a slot because
+of it — a preference, not a limit.
+
+## Two kinds of opening/closing counters
+
+- **Capped counters** (`assignedOpeningCountByUser` / `assignedClosingCountByUser`) — exclude
+  mandatory events. Used only to enforce the hard caps in Phases 1 and 3 (non-mandatory anchors
+  and tenders).
+- **True-total counters** (`totalOpeningCountByUser` / `totalClosingCountByUser`) — count
+  everything: anchor or tender, mandatory or not. Used only to *steer* Phases 4 and 5's mandatory
+  placement toward whichever category someone's behind on — never to cap them, since the mandatory
+  guarantee always wins.
+
+## Level-filling, in one sentence
+
+Instead of matching as many people as possible in one shot (which has no fairness objective —
+it just maximizes the number of filled slots), each fill loop repeats in rounds, and within a
+round only offers slots to whoever currently has the fewest shifts among people who still have an
+eligible slot at all. That's what stops one person ending up at 7 shifts while someone equally
+available sits at 3 — nobody gets a *second* shift while someone eligible is still at zero.
+
+## Requirements checklist
+
+Verified against the actual code, not just the design intent. Status as of the last review:
+
+| # | Requirement | Status | Notes |
+|---|---|---|---|
+| 1 | At most "total tenders including anchors" on each shift | ✅ non-mandatory / ⚪ N/A mandatory | Non-mandatory: `tenderSlots` are built as `configuredTenders - assignedAnchorsOnShift - assignedTendersOnShift`, so anchors+tenders together never exceed `shift.tenders`. **Deliberately not enforced for mandatory shifts** — mandatory means everyone eligible works regardless of capacity; Phase 5 only uses load as a sort *preference*, never a hard cap. |
+| 2 | At most one shift per event per user (anchor + tender combined) | ✅ fixed | Phase 3/5's tender checks already enforced this via `assignedEventsByUser`. Phase 1/4's anchor check (`canTakeAnchorSlot`) did **not** until this review — found and fixed: without it, one experienced anchor could be matched to two different shifts of the same event (e.g. its opening and closing shift both needing an anchor). |
+| 3 | `anchorOnly` users never get a tender shift | ✅ holds | Doubly enforced: `regularUsers` (used by Phases 3 and 5) excludes `anchorOnly` entirely, and `canTakeTenderSlot` also explicitly returns `false` for them. |
+| 4 | Tenders only assigned shifts they can actually be part of | ✅ holds | Every phase's eligibility check ends with `effectiveAvailability(...)`, plus same-shift and avoid-conflict checks. |
+| 5 | Users get approximately equal opening-shift counts | ✅ holds (capped non-mandatory, steered mandatory) | Non-mandatory (Phases 1 and 3): hard-capped at `perUserOpeningCap`, for both anchors (`canTakeAnchorSlot`) and tenders (`canTakeTenderSlot`) — closes the gap found in the previous review. Mandatory (Phases 4 and 5): never capped — mandatory is an add-on, guaranteed regardless of load — but still steered toward whichever category someone's currently lower on, using the true-total counters. |
+| 6 | Users get approximately equal closing-shift counts | ✅ holds (capped non-mandatory, steered mandatory) | Same mechanism as #5, mirrored for `perUserClosingCap`. |
+| 7 | Tenders capped at `ceil(shifts per member)` | ✅ holds | `perUserTotalCap` bounds each person's *total* (anchor+tender combined); tender-count is always ≤ total, so it's always within the cap. Denominator is `activeUsers.length` (all active members, matching the existing admin UI "shifts per member" stat) rather than tender-eligible members only — a deliberate choice for consistency, not a bug. |
+| 8 | If a user can join any shift in a mandatory event, they get one that day | ✅ holds | Phase 5 always assigns when `candidateShifts` is non-empty — no cap check can block it, by design. |
+| 9 | If a user can't join any shift in a mandatory event, they get nothing that day | ✅ holds | Phase 5 never assigns when `candidateShifts` is empty; only logs a warning if they had availability that went unmatched for another reason. |
+| 10 | Users on each other's avoid-list never share a shift | ✅ holds | Checked via `hasAvoidConflictOnShift` in every phase — Phase 1/4 (`canTakeAnchorSlot` + level-fill filtering), Phase 2 (`hasConflict` passed to the matcher), Phase 3 (`canTakeTenderSlot` + level-fill filtering), Phase 5 (candidate-shift filter). |
+
+**Open gap**: rows 5/6. If anchor-duty opening/closing balance matters as much as tender-duty
+balance, Phase 1/4's slot choice would need the same category-steering treatment Phase 3/5
+already have — currently out of scope, not yet implemented.

--- a/functions/src/shiftPlanning/firebaseData.ts
+++ b/functions/src/shiftPlanning/firebaseData.ts
@@ -1,6 +1,13 @@
 import * as admin from 'firebase-admin';
 import { HttpsError } from 'firebase-functions/v2/https';
-import { engagementType, Role, Shift, ShiftPlanningSurveyType, Tender } from '../types/types-file';
+import {
+  engagementType,
+  Role,
+  Shift,
+  ShiftPlanningPeriodStatus,
+  ShiftPlanningSurveyType,
+  Tender,
+} from '../types/types-file';
 import {
   PlanningPeriodDoc,
   ShiftPlanningResponseDoc,
@@ -44,7 +51,8 @@ export type PersistPlannerResultParams = {
   eventIds: string[];
   shifts: Shift[];
   assignments: ShiftAssignmentRecord[];
-  roleUpdates: Array<{ userId: string; roles: string[] }>;
+  roleUpdates: Array<{ userId: string; roles: string[]; previousRoles: string[] }>;
+  previousStatus: ShiftPlanningPeriodStatus;
   expectedSubmissions: number;
   submittedCount: number;
   assignedAnchorCount: number;
@@ -245,6 +253,7 @@ export const persistPlannerResult = async (
     shifts,
     assignments,
     roleUpdates,
+    previousStatus,
     expectedSubmissions,
     submittedCount,
     assignedAnchorCount,
@@ -269,6 +278,16 @@ export const persistPlannerResult = async (
       )
     );
   }
+
+  // Pre-generation snapshot — engagement ids that existed before this run, the period's
+  // previous status, and the roles every affected user had before promotion/passive/legacy
+  // sync. "Reset period" restores exactly this. Captured from data already loaded above, so
+  // no extra reads.
+  const preGenerationSnapshot = {
+    status: previousStatus,
+    engagementIds: existingEngagementDocs.map((doc) => doc.id),
+    roleSnapshots: roleUpdates.map(({ userId, previousRoles }) => ({ userId, roles: previousRoles })),
+  };
 
   const writer = db.bulkWriter();
 
@@ -332,6 +351,7 @@ export const persistPlannerResult = async (
         unfilledAnchorSlots,
         unfilledTenderSlots,
       },
+      preGenerationSnapshot,
     },
     { merge: true }
   );

--- a/functions/src/shiftPlanning/generateShiftPlan.ts
+++ b/functions/src/shiftPlanning/generateShiftPlan.ts
@@ -1,5 +1,5 @@
 import { CallableRequest, HttpsError, onCall } from 'firebase-functions/v2/https';
-import { engagementType, Role } from '../types/types-file';
+import { engagementType, Role, Shift } from '../types/types-file';
 import {
   User,
   ShiftCategory,
@@ -8,6 +8,7 @@ import {
   getResponseAvailability,
   getShiftCategoryMap,
   resolveSurveyType,
+  shuffle,
 } from './helpers';
 import {
   ShiftAssignmentRecord,
@@ -265,9 +266,14 @@ export const generateShiftPlan = onCall(
     const assignedAnchorCountByUser = new Map<string, number>();
     const assignedTenderCountByUser = new Map<string, number>();
     const totalAssignedCountByUser = new Map<string, number>();
-    // Per-category caps (max 2 opening, 2 closing per user per period; mandatory events excluded).
+    // Dynamic per-period caps (see perUserOpeningCap/perUserClosingCap further down); mandatory
+    // events are excluded from these two so mandatory duty never eats into the capped allowance.
     const assignedOpeningCountByUser = new Map<string, number>();
     const assignedClosingCountByUser = new Map<string, number>();
+    // True total exposure regardless of mandatory/anchor-vs-tender — used only to steer mandatory
+    // placement toward whichever category a person is currently lower on, never for caps.
+    const totalOpeningCountByUser = new Map<string, number>();
+    const totalClosingCountByUser = new Map<string, number>();
 
     for (const user of userList) {
       assignedEventsByUser.set(user.uid, new Set<string>());
@@ -276,6 +282,8 @@ export const generateShiftPlan = onCall(
       totalAssignedCountByUser.set(user.uid, 0);
       assignedOpeningCountByUser.set(user.uid, 0);
       assignedClosingCountByUser.set(user.uid, 0);
+      totalOpeningCountByUser.set(user.uid, 0);
+      totalClosingCountByUser.set(user.uid, 0);
     }
 
     for (const assignment of existingAssignments) {
@@ -302,12 +310,18 @@ export const generateShiftPlan = onCall(
         );
       }
 
-      // Seed opening/closing caps from pre-existing assignments; mandatory events are excluded.
+      // Seed opening/closing counters from pre-existing assignments. The capped counters
+      // exclude mandatory events; the true-total counters always count everything.
+      const preExistingCategory = categoryByShiftId.get(assignment.shiftId);
+      if (preExistingCategory === 'opening') {
+        totalOpeningCountByUser.set(assignment.userId, (totalOpeningCountByUser.get(assignment.userId) ?? 0) + 1);
+      } else if (preExistingCategory === 'closing') {
+        totalClosingCountByUser.set(assignment.userId, (totalClosingCountByUser.get(assignment.userId) ?? 0) + 1);
+      }
       if (!mandatoryEventIds.has(assignment.eventId)) {
-        const cat = categoryByShiftId.get(assignment.shiftId);
-        if (cat === 'opening') {
+        if (preExistingCategory === 'opening') {
           assignedOpeningCountByUser.set(assignment.userId, (assignedOpeningCountByUser.get(assignment.userId) ?? 0) + 1);
-        } else if (cat === 'closing') {
+        } else if (preExistingCategory === 'closing') {
           assignedClosingCountByUser.set(assignment.userId, (assignedClosingCountByUser.get(assignment.userId) ?? 0) + 1);
         }
       }
@@ -332,33 +346,96 @@ export const generateShiftPlan = onCall(
       );
     }
 
-    // Build anchor capacity from shifts (at least one anchor slot per shift).
+    // Live-updated as anchor assignments are made across phases 1, 2, and 4, so phases 3 and 5
+    // (which both need to know who's already anchoring which shift) always see the full picture.
+    const anchorShiftIdsByUser = new Map<string, Set<string>>();
+    for (const assignment of existingAssignments) {
+      if (assignment.type !== engagementType.ANCHOR) {
+        continue;
+      }
+      const preExisting = anchorShiftIdsByUser.get(assignment.userId) ?? new Set<string>();
+      preExisting.add(assignment.shiftId);
+      anchorShiftIdsByUser.set(assignment.userId, preExisting);
+    }
+    const recordAnchorAssignment = (userId: string, shiftId: string): void => {
+      const current = anchorShiftIdsByUser.get(userId) ?? new Set<string>();
+      current.add(shiftId);
+      anchorShiftIdsByUser.set(userId, current);
+    };
+
+    // Dynamic per-period caps, scaled to this period's own non-mandatory shift-to-member ratio
+    // instead of a fixed number — mirrors the "shifts per member" stat already shown in the
+    // admin UI. Mandatory events are excluded from the capacity totals since mandatory duty is
+    // guaranteed regardless of load, not something these caps are meant to bound.
+    const sumNonMandatoryTenders = (predicate: (shift: Shift) => boolean): number =>
+      shifts
+        .filter((shift) => !mandatoryEventIds.has(shift.eventId) && predicate(shift))
+        .reduce((sum, shift) => sum + (Number.isFinite(shift.tenders) ? shift.tenders : 0), 0);
+
+    const perMemberCap = (capacity: number): number =>
+      activeUsers.length > 0 ? Math.max(1, Math.ceil(capacity / activeUsers.length)) : 1;
+
+    const perUserTotalCap = perMemberCap(sumNonMandatoryTenders(() => true));
+    const perUserOpeningCap = perMemberCap(sumNonMandatoryTenders((shift) => categoryByShiftId.get(shift.id) === 'opening'));
+    const perUserClosingCap = perMemberCap(sumNonMandatoryTenders((shift) => categoryByShiftId.get(shift.id) === 'closing'));
+
+    // Build anchor capacity (at least one anchor slot per shift). Mandatory shifts get their own
+    // pool, filled in Phase 4 after non-mandatory tenders so it's informed by the full picture.
     const anchorSlots: Slot[] = [];
+    const mandatoryAnchorSlots: Slot[] = [];
     for (const shift of shifts) {
       const existingAnchors = assignedAnchorsByShiftId.get(shift.id) ?? 0;
       if (existingAnchors >= 1) {
         continue;
       }
 
-      anchorSlots.push({
+      const slot: Slot = {
         id: `${shift.id}::anchor`,
         shiftId: shift.id,
         eventId: shift.eventId,
         category: categoryByShiftId.get(shift.id) ?? 'other',
-      });
+      };
+
+      if (mandatoryEventIds.has(shift.eventId)) {
+        mandatoryAnchorSlots.push(slot);
+      } else {
+        anchorSlots.push(slot);
+      }
     }
 
     const anchorUsers = activeUsers.filter((user) => user.wantsAnchor);
 
-    // Phase 1: place experienced anchors first - 1 per shift.
+    // Phase 1: place experienced anchors on non-mandatory shifts.
     const experiencedAnchors = anchorUsers.filter((user) => user.experiencedAnchor);
+    // anchorOnly members have no tender fallback — their entire workload comes from anchor
+    // duty, so they get priority access to the shared fair-share cap ahead of mixed anchors.
+    const experiencedAnchorOnly = experiencedAnchors.filter((user) => user.anchorOnly);
+    const experiencedAnchorMixed = experiencedAnchors.filter((user) => !user.anchorOnly);
 
-    const canTakeAnchorSlot = (user: User, slot: Slot): boolean => {
+    // applyCaps is true for Phase 1 (non-mandatory) and false for Phase 4 (mandatory) — mandatory
+    // anchor duty is an add-on, guaranteed on top of non-mandatory scheduling, so it's never
+    // blocked by the fair-share caps. It still steers toward whichever category someone's lower
+    // on (see chosenSlot selection below), it just never refuses a slot because of it.
+    const canTakeAnchorSlot = (user: User, slot: Slot, applyCaps: boolean): boolean => {
       if (!user.experiencedAnchor || !user.wantsAnchor || user.participationStatus !== 'active') {
         return false;
       }
       if (assignedUserIdsByShiftId.get(slot.shiftId)?.has(user.uid) === true) {
         return false;
+      }
+      // One shift per event, whether anchor or tender — without this, one experienced anchor
+      // could be matched to two different shifts of the same event (e.g. its opening and
+      // closing shift both needing an anchor).
+      if (assignedEventsByUser.get(user.uid)?.has(slot.eventId) === true) {
+        return false;
+      }
+      if (applyCaps) {
+        if (slot.category === 'opening' && (totalOpeningCountByUser.get(user.uid) ?? 0) >= perUserOpeningCap) {
+          return false;
+        }
+        if (slot.category === 'closing' && (totalClosingCountByUser.get(user.uid) ?? 0) >= perUserClosingCap) {
+          return false;
+        }
       }
       if (hasAvoidConflictOnShift(user.uid, slot.shiftId)) {
         return false;
@@ -366,48 +443,112 @@ export const generateShiftPlan = onCall(
       return effectiveAvailability(user.uid, slot.shiftId);
     };
 
-    const anchorPhase1 = assignSlotsRoundRobin({
-      slots: anchorSlots,
-      users: experiencedAnchors,
-      assignedEventsByUser,
-      assignedCountByUser: assignedAnchorCountByUser,
-      canTake: canTakeAnchorSlot,
-      hasConflict: hasAvoidConflict,
-      onAssigned: onSlotAssigned,
-    });
+    // Level-fills a pool of anchor slots: anchorOnly candidates first (see above), then mixed
+    // candidates on whatever remains. Within each group, whoever currently has the fewest total
+    // shifts goes first each round, so anchor duty is spread as evenly as tender duty. When a
+    // choice exists between an opening and closing slot, steers toward whichever category the
+    // person currently has fewer of — same idea as the tender fill, just never a hard block when
+    // applyCaps is false (mandatory).
+    const fillAnchorSlotsFairly = (
+      remaining: Map<string, Slot>,
+      anchorOnlyUsers: User[],
+      mixedUsers: User[],
+      applyCaps: boolean
+    ): void => {
+      const levelFillGroup = (candidates: User[]): void => {
+        let progress = true;
+        while (progress && remaining.size > 0) {
+          progress = false;
 
-    // Persist anchor assignments
-    for (const assignment of anchorPhase1.assignments) {
-      const slot = anchorSlots.find((candidate) => candidate.id === assignment.slotId);
-      if (!slot) {
-        continue;
-      }
-      allAssignments.push({
-        userId: assignment.userId,
-        shiftId: slot.shiftId,
-        eventId: slot.eventId,
-        type: engagementType.ANCHOR,
-      });
-      plannedAssignments.push({
-        userId: assignment.userId,
-        shiftId: slot.shiftId,
-        eventId: slot.eventId,
-        type: engagementType.ANCHOR,
-      });
+          const slotList = Array.from(remaining.values());
+          const eligible = candidates.filter(
+            (user) =>
+              (!applyCaps || (totalAssignedCountByUser.get(user.uid) ?? 0) < perUserTotalCap) &&
+              slotList.some(
+                (slot) => canTakeAnchorSlot(user, slot, applyCaps) && !hasAvoidConflictOnShift(user.uid, slot.shiftId)
+              )
+          );
+          if (eligible.length === 0) {
+            break;
+          }
 
-      assignedAnchorsByShiftId.set(slot.shiftId, (assignedAnchorsByShiftId.get(slot.shiftId) ?? 0) + 1);
-      totalAssignedCountByUser.set(
-        assignment.userId,
-        (totalAssignedCountByUser.get(assignment.userId) ?? 0) + 1
-      );
-      if (!mandatoryEventIds.has(slot.eventId)) {
-        if (slot.category === 'opening') {
-          assignedOpeningCountByUser.set(assignment.userId, (assignedOpeningCountByUser.get(assignment.userId) ?? 0) + 1);
-        } else if (slot.category === 'closing') {
-          assignedClosingCountByUser.set(assignment.userId, (assignedClosingCountByUser.get(assignment.userId) ?? 0) + 1);
+          const minCount = Math.min(...eligible.map((user) => totalAssignedCountByUser.get(user.uid) ?? 0));
+          const tierUsers = shuffle(eligible.filter((user) => (totalAssignedCountByUser.get(user.uid) ?? 0) === minCount));
+
+          for (const user of tierUsers) {
+            const candidateSlots = Array.from(remaining.values()).filter(
+              (slot) => canTakeAnchorSlot(user, slot, applyCaps) && !hasAvoidConflictOnShift(user.uid, slot.shiftId)
+            );
+            if (candidateSlots.length === 0) {
+              continue;
+            }
+
+            const openingCandidates = candidateSlots.filter((slot) => slot.category === 'opening');
+            const closingCandidates = candidateSlots.filter((slot) => slot.category === 'closing');
+
+            let categoryPool: Slot[];
+            if (openingCandidates.length > 0 && closingCandidates.length > 0) {
+              const openingCount = totalOpeningCountByUser.get(user.uid) ?? 0;
+              const closingCount = totalClosingCountByUser.get(user.uid) ?? 0;
+              categoryPool = openingCount <= closingCount ? openingCandidates : closingCandidates;
+            } else if (openingCandidates.length > 0) {
+              categoryPool = openingCandidates;
+            } else if (closingCandidates.length > 0) {
+              categoryPool = closingCandidates;
+            } else {
+              categoryPool = candidateSlots;
+            }
+
+            const [chosenSlot] = shuffle(categoryPool);
+            remaining.delete(chosenSlot.id);
+
+            allAssignments.push({
+              userId: user.uid,
+              shiftId: chosenSlot.shiftId,
+              eventId: chosenSlot.eventId,
+              type: engagementType.ANCHOR,
+            });
+            plannedAssignments.push({
+              userId: user.uid,
+              shiftId: chosenSlot.shiftId,
+              eventId: chosenSlot.eventId,
+              type: engagementType.ANCHOR,
+            });
+
+            markAssignedToShift(user.uid, chosenSlot.shiftId);
+            recordAnchorAssignment(user.uid, chosenSlot.shiftId);
+            assignedAnchorsByShiftId.set(chosenSlot.shiftId, (assignedAnchorsByShiftId.get(chosenSlot.shiftId) ?? 0) + 1);
+            assignedAnchorCountByUser.set(user.uid, (assignedAnchorCountByUser.get(user.uid) ?? 0) + 1);
+            totalAssignedCountByUser.set(user.uid, (totalAssignedCountByUser.get(user.uid) ?? 0) + 1);
+
+            const userEvents = assignedEventsByUser.get(user.uid) ?? new Set<string>();
+            userEvents.add(chosenSlot.eventId);
+            assignedEventsByUser.set(user.uid, userEvents);
+
+            if (chosenSlot.category === 'opening') {
+              totalOpeningCountByUser.set(user.uid, (totalOpeningCountByUser.get(user.uid) ?? 0) + 1);
+            } else if (chosenSlot.category === 'closing') {
+              totalClosingCountByUser.set(user.uid, (totalClosingCountByUser.get(user.uid) ?? 0) + 1);
+            }
+            if (!mandatoryEventIds.has(chosenSlot.eventId)) {
+              if (chosenSlot.category === 'opening') {
+                assignedOpeningCountByUser.set(user.uid, (assignedOpeningCountByUser.get(user.uid) ?? 0) + 1);
+              } else if (chosenSlot.category === 'closing') {
+                assignedClosingCountByUser.set(user.uid, (assignedClosingCountByUser.get(user.uid) ?? 0) + 1);
+              }
+            }
+
+            progress = true;
+          }
         }
-      }
-    }
+      };
+
+      levelFillGroup(anchorOnlyUsers);
+      levelFillGroup(mixedUsers);
+    };
+
+    const remainingAnchorSlots = new Map<string, Slot>(anchorSlots.map((slot) => [slot.id, slot]));
+    fillAnchorSlotsFairly(remainingAnchorSlots, experiencedAnchorOnly, experiencedAnchorMixed, true);
 
     // Phase 2: assign new anchors one opening and one closing shift each.
     const experiencedAnchorShiftIds = new Set<string>();
@@ -532,6 +673,8 @@ export const generateShiftPlan = onCall(
         assignment.userId,
         (totalAssignedCountByUser.get(assignment.userId) ?? 0) + 1
       );
+      recordAnchorAssignment(assignment.userId, assignment.shiftId);
+      totalOpeningCountByUser.set(assignment.userId, (totalOpeningCountByUser.get(assignment.userId) ?? 0) + 1);
       if (!mandatoryEventIds.has(assignment.eventId)) {
         assignedOpeningCountByUser.set(assignment.userId, (assignedOpeningCountByUser.get(assignment.userId) ?? 0) + 1);
       }
@@ -592,6 +735,8 @@ export const generateShiftPlan = onCall(
         assignment.userId,
         (totalAssignedCountByUser.get(assignment.userId) ?? 0) + 1
       );
+      recordAnchorAssignment(assignment.userId, assignment.shiftId);
+      totalClosingCountByUser.set(assignment.userId, (totalClosingCountByUser.get(assignment.userId) ?? 0) + 1);
       if (!mandatoryEventIds.has(assignment.eventId)) {
         assignedClosingCountByUser.set(assignment.userId, (assignedClosingCountByUser.get(assignment.userId) ?? 0) + 1);
       }
@@ -632,20 +777,13 @@ export const generateShiftPlan = onCall(
       }
     }
 
-    // Phase 3: Assign tenders for the remaining shift capacity
+    // Phase 3: unified, level-filled non-mandatory tender assignment. Every remaining
+    // non-mandatory tender slot, regardless of category, is considered together (fixes the old
+    // opening-then-closing-then-middle phase order, which let one category exhaust the eligible
+    // pool before the next was even considered). Each pass only offers slots to whoever
+    // currently has the fewest total shifts among people who still have an eligible slot, and
+    // whoever has fewer openings vs closings so far is steered toward whichever they need.
     const remainingTenderSlots = new Map<string, Slot>(tenderSlots.map((slot) => [slot.id, slot]));
-
-    const anchorShiftIdsByUser = new Map<string, Set<string>>();
-    for (const assignment of allAssignments) {
-      if (assignment.type !== engagementType.ANCHOR) {
-        continue;
-      }
-
-      const current = anchorShiftIdsByUser.get(assignment.userId) ?? new Set<string>();
-      current.add(assignment.shiftId);
-      anchorShiftIdsByUser.set(assignment.userId, current);
-    }
-
     const regularUsers = activeUsers.filter((user) => !user.anchorOnly);
     const unmetMandatoryWarnings: Array<{ eventId: string; userId: string }> = [];
 
@@ -654,16 +792,16 @@ export const generateShiftPlan = onCall(
         return false;
       }
 
-      // Users should not be assigned to more than 5 shifts
-      if ((totalAssignedCountByUser.get(user.uid) ?? 0) >= 5) {
+      // Dynamic per-period cap instead of a fixed number — see perUserTotalCap above.
+      if ((totalAssignedCountByUser.get(user.uid) ?? 0) >= perUserTotalCap) {
         return false;
       }
 
-      // Per-period cap: at most 2 opening and 2 closing shifts (mandatory events excluded).
-      if (slot.category === 'opening' && (assignedOpeningCountByUser.get(user.uid) ?? 0) >= 2) {
+      // Dynamic per-period opening/closing caps (mandatory events excluded from the totals they're based on).
+      if (slot.category === 'opening' && (assignedOpeningCountByUser.get(user.uid) ?? 0) >= perUserOpeningCap) {
         return false;
       }
-      if (slot.category === 'closing' && (assignedClosingCountByUser.get(user.uid) ?? 0) >= 2) {
+      if (slot.category === 'closing' && (assignedClosingCountByUser.get(user.uid) ?? 0) >= perUserClosingCap) {
         return false;
       }
 
@@ -688,49 +826,168 @@ export const generateShiftPlan = onCall(
       return effectiveAvailability(user.uid, slot.shiftId);
     };
 
+    const fillTenderSlotsFairly = (remaining: Map<string, Slot>): void => {
+      let progress = true;
+      while (progress && remaining.size > 0) {
+        progress = false;
+
+        const slotList = Array.from(remaining.values());
+        const eligibleUsers = regularUsers.filter((user) =>
+          slotList.some((slot) => canTakeTenderSlot(user, slot) && !hasAvoidConflictOnShift(user.uid, slot.shiftId))
+        );
+        if (eligibleUsers.length === 0) {
+          break;
+        }
+
+        const minCount = Math.min(...eligibleUsers.map((user) => totalAssignedCountByUser.get(user.uid) ?? 0));
+        const tierUsers = shuffle(eligibleUsers.filter((user) => (totalAssignedCountByUser.get(user.uid) ?? 0) === minCount));
+
+        for (const user of tierUsers) {
+          const candidates = Array.from(remaining.values()).filter(
+            (slot) => canTakeTenderSlot(user, slot) && !hasAvoidConflictOnShift(user.uid, slot.shiftId)
+          );
+          if (candidates.length === 0) {
+            continue;
+          }
+
+          const openingCandidates = candidates.filter((slot) => slot.category === 'opening');
+          const closingCandidates = candidates.filter((slot) => slot.category === 'closing');
+
+          let categoryPool: Slot[];
+          if (openingCandidates.length > 0 && closingCandidates.length > 0) {
+            const openingCount = assignedOpeningCountByUser.get(user.uid) ?? 0;
+            const closingCount = assignedClosingCountByUser.get(user.uid) ?? 0;
+            categoryPool = openingCount <= closingCount ? openingCandidates : closingCandidates;
+          } else if (openingCandidates.length > 0) {
+            categoryPool = openingCandidates;
+          } else if (closingCandidates.length > 0) {
+            categoryPool = closingCandidates;
+          } else {
+            categoryPool = candidates;
+          }
+
+          // Spread within the chosen category by preferring whichever specific shift currently
+          // has the fewest people on it — otherwise slots would fill in the same fixed array
+          // order every time, recreating the exact early-shift bias this replaces.
+          const [chosenSlot] = shuffle(categoryPool).sort(
+            (a, b) =>
+              (assignedUserIdsByShiftId.get(a.shiftId)?.size ?? 0) - (assignedUserIdsByShiftId.get(b.shiftId)?.size ?? 0)
+          );
+
+          remaining.delete(chosenSlot.id);
+          onTenderSlotAssigned(user, chosenSlot);
+          assignedTenderCountByUser.set(user.uid, (assignedTenderCountByUser.get(user.uid) ?? 0) + 1);
+          if (chosenSlot.category === 'opening') {
+            totalOpeningCountByUser.set(user.uid, (totalOpeningCountByUser.get(user.uid) ?? 0) + 1);
+          } else if (chosenSlot.category === 'closing') {
+            totalClosingCountByUser.set(user.uid, (totalClosingCountByUser.get(user.uid) ?? 0) + 1);
+          }
+
+          const userEvents = assignedEventsByUser.get(user.uid) ?? new Set<string>();
+          userEvents.add(chosenSlot.eventId);
+          assignedEventsByUser.set(user.uid, userEvents);
+
+          allAssignments.push({
+            userId: user.uid,
+            shiftId: chosenSlot.shiftId,
+            eventId: chosenSlot.eventId,
+            type: engagementType.TENDER,
+          });
+          plannedAssignments.push({
+            userId: user.uid,
+            shiftId: chosenSlot.shiftId,
+            eventId: chosenSlot.eventId,
+            type: engagementType.TENDER,
+          });
+
+          progress = true;
+        }
+      }
+    };
+
+    fillTenderSlotsFairly(remainingTenderSlots);
+
+    // Phase 4: mandatory-event anchors, run after non-mandatory tenders so it's informed by the
+    // full non-mandatory picture. Same anchorOnly-first-then-mixed leveled fill as Phase 1.
+    const remainingMandatoryAnchorSlots = new Map<string, Slot>(mandatoryAnchorSlots.map((slot) => [slot.id, slot]));
+    fillAnchorSlotsFairly(remainingMandatoryAnchorSlots, experiencedAnchorOnly, experiencedAnchorMixed, false);
+
+    // Phase 5: mandatory-event tenders. Everyone eligible and available is guaranteed a shift
+    // regardless of load (no total-shift cap applies) — the only real decision is which of the
+    // event's own shifts they land on. Steered toward whichever category (opening/closing) a
+    // person is currently lower on overall (true-total counters, which include mandatory +
+    // anchor exposure), and spread across the event's own shifts by current fill level so one
+    // shift doesn't get overloaded while a sibling shift sits empty.
     for (const mandatoryEventId of mandatoryEventIds) {
       const eventShifts = shifts.filter((shift) => shift.eventId === mandatoryEventId);
       if (eventShifts.length === 0) {
         continue;
       }
 
-      for (const user of regularUsers) {
-        // Skip if already assigned to this event
+      const assignedCountByShiftId = new Map<string, number>();
+
+      for (const user of shuffle(regularUsers)) {
         if (assignedEventsByUser.get(user.uid)?.has(mandatoryEventId) === true) {
           continue;
         }
 
-        // Respect the 5-shift cap
-        if ((totalAssignedCountByUser.get(user.uid) ?? 0) >= 5) {
-          continue;
-        }
-
-        // Find any shift in this event the user can take (ignoring slot capacity)
-        const availableShift = eventShifts.find((shift) =>
-          anchorShiftIdsByUser.get(user.uid)?.has(shift.id) !== true &&
-          assignedUserIdsByShiftId.get(shift.id)?.has(user.uid) !== true &&
-          !hasAvoidConflictOnShift(user.uid, shift.id) &&
-          effectiveAvailability(user.uid, shift.id)
+        const candidateShifts = eventShifts.filter(
+          (shift) =>
+            anchorShiftIdsByUser.get(user.uid)?.has(shift.id) !== true &&
+            assignedUserIdsByShiftId.get(shift.id)?.has(user.uid) !== true &&
+            !hasAvoidConflictOnShift(user.uid, shift.id) &&
+            effectiveAvailability(user.uid, shift.id)
         );
 
-        if (availableShift) {
-          markAssignedToShift(user.uid, availableShift.id);
-          totalAssignedCountByUser.set(user.uid, (totalAssignedCountByUser.get(user.uid) ?? 0) + 1);
-          assignedTenderCountByUser.set(user.uid, (assignedTenderCountByUser.get(user.uid) ?? 0) + 1);
-          const userEvents = assignedEventsByUser.get(user.uid) ?? new Set<string>();
-          userEvents.add(mandatoryEventId);
-          assignedEventsByUser.set(user.uid, userEvents);
-          allAssignments.push({ userId: user.uid, shiftId: availableShift.id, eventId: mandatoryEventId, type: engagementType.TENDER });
-          plannedAssignments.push({ userId: user.uid, shiftId: availableShift.id, eventId: mandatoryEventId, type: engagementType.TENDER });
-        } else {
+        if (candidateShifts.length === 0) {
           // Only flag as unmet if the user had availability for at least one shift in this event
-          const couldWork = eventShifts.some((shift) =>
-            effectiveAvailability(user.uid, shift.id)
-          );
+          const couldWork = eventShifts.some((shift) => effectiveAvailability(user.uid, shift.id));
           if (couldWork) {
             unmetMandatoryWarnings.push({ eventId: mandatoryEventId, userId: user.uid });
           }
+          continue;
         }
+
+        const openingCandidates = candidateShifts.filter((shift) => categoryByShiftId.get(shift.id) === 'opening');
+        const closingCandidates = candidateShifts.filter((shift) => categoryByShiftId.get(shift.id) === 'closing');
+
+        let categoryPool: Shift[];
+        if (openingCandidates.length > 0 && closingCandidates.length > 0) {
+          const openingCount = totalOpeningCountByUser.get(user.uid) ?? 0;
+          const closingCount = totalClosingCountByUser.get(user.uid) ?? 0;
+          categoryPool = openingCount <= closingCount ? openingCandidates : closingCandidates;
+        } else if (openingCandidates.length > 0) {
+          categoryPool = openingCandidates;
+        } else if (closingCandidates.length > 0) {
+          categoryPool = closingCandidates;
+        } else {
+          categoryPool = candidateShifts;
+        }
+
+        const [chosenShift] = shuffle(categoryPool).sort((a, b) => {
+          const aLoad = (assignedCountByShiftId.get(a.id) ?? 0) / Math.max(1, Number.isFinite(a.tenders) ? a.tenders : 1);
+          const bLoad = (assignedCountByShiftId.get(b.id) ?? 0) / Math.max(1, Number.isFinite(b.tenders) ? b.tenders : 1);
+          return aLoad - bLoad;
+        });
+
+        assignedCountByShiftId.set(chosenShift.id, (assignedCountByShiftId.get(chosenShift.id) ?? 0) + 1);
+        markAssignedToShift(user.uid, chosenShift.id);
+        totalAssignedCountByUser.set(user.uid, (totalAssignedCountByUser.get(user.uid) ?? 0) + 1);
+        assignedTenderCountByUser.set(user.uid, (assignedTenderCountByUser.get(user.uid) ?? 0) + 1);
+
+        const chosenCategory = categoryByShiftId.get(chosenShift.id);
+        if (chosenCategory === 'opening') {
+          totalOpeningCountByUser.set(user.uid, (totalOpeningCountByUser.get(user.uid) ?? 0) + 1);
+        } else if (chosenCategory === 'closing') {
+          totalClosingCountByUser.set(user.uid, (totalClosingCountByUser.get(user.uid) ?? 0) + 1);
+        }
+
+        const userEvents = assignedEventsByUser.get(user.uid) ?? new Set<string>();
+        userEvents.add(mandatoryEventId);
+        assignedEventsByUser.set(user.uid, userEvents);
+
+        allAssignments.push({ userId: user.uid, shiftId: chosenShift.id, eventId: mandatoryEventId, type: engagementType.TENDER });
+        plannedAssignments.push({ userId: user.uid, shiftId: chosenShift.id, eventId: mandatoryEventId, type: engagementType.TENDER });
       }
     }
 
@@ -739,86 +996,6 @@ export const generateShiftPlan = onCall(
         code: 'mandatory_assignment_not_met',
         message: `${userById.get(userId)?.displayName ?? userId} indicated availability for a mandatory event but could not be assigned`,
         details: { userId, eventId },
-      });
-    }
-
-    const remainingTenderSlotList = () => Array.from(remainingTenderSlots.values());
-
-    // Soft per-user cap keeps tender load from concentrating on a few users.
-    const baseMaxPerUser =
-      regularUsers.length > 0
-        ? Math.max(1, Math.ceil(tenderSlots.length / regularUsers.length) + 1)
-        : 0;
-
-    // Fairness pass: fill by shift category before relaxed catch-all fill.
-    const categoryOrder: ShiftCategory[] = ['opening', 'closing', 'middle', 'other'];
-    for (const category of categoryOrder) {
-      const categorySlots = remainingTenderSlotList().filter((slot) => slot.category === category);
-      if (categorySlots.length === 0) {
-        continue;
-      }
-
-      const categoryAssignments = assignSlotsRoundRobin({
-        slots: categorySlots,
-        users: regularUsers,
-        assignedEventsByUser,
-        assignedCountByUser: assignedTenderCountByUser,
-        canTake: canTakeTenderSlot,
-        maxPerUser: baseMaxPerUser,
-        hasConflict: hasAvoidConflict,
-        onAssigned: onTenderSlotAssigned,
-      });
-
-      for (const assignment of categoryAssignments.assignments) {
-        const slot = categorySlots.find((candidate) => candidate.id === assignment.slotId);
-        if (!slot) {
-          continue;
-        }
-
-        remainingTenderSlots.delete(slot.id);
-        allAssignments.push({
-          userId: assignment.userId,
-          shiftId: slot.shiftId,
-          eventId: slot.eventId,
-          type: engagementType.TENDER,
-        });
-        plannedAssignments.push({
-          userId: assignment.userId,
-          shiftId: slot.shiftId,
-          eventId: slot.eventId,
-          type: engagementType.TENDER,
-        });
-      }
-    }
-
-    // Final pass: relax category balancing to maximize total filled slots.
-    const relaxedFillAssignments = assignSlotsRoundRobin({
-      slots: remainingTenderSlotList(),
-      users: regularUsers,
-      assignedEventsByUser,
-      assignedCountByUser: assignedTenderCountByUser,
-      canTake: canTakeTenderSlot,
-      hasConflict: hasAvoidConflict,
-      onAssigned: onTenderSlotAssigned,
-    });
-
-    for (const assignment of relaxedFillAssignments.assignments) {
-      const slot = remainingTenderSlots.get(assignment.slotId);
-      if (!slot) {
-        continue;
-      }
-      remainingTenderSlots.delete(slot.id);
-      allAssignments.push({
-        userId: assignment.userId,
-        shiftId: slot.shiftId,
-        eventId: slot.eventId,
-        type: engagementType.TENDER,
-      });
-      plannedAssignments.push({
-        userId: assignment.userId,
-        shiftId: slot.shiftId,
-        eventId: slot.eventId,
-        type: engagementType.TENDER,
       });
     }
 

--- a/functions/src/shiftPlanning/generateShiftPlan.ts
+++ b/functions/src/shiftPlanning/generateShiftPlan.ts
@@ -61,6 +61,17 @@ export const generateShiftPlan = onCall(
       env,
       periodId
     );
+    // Guard: generation only ever runs once per period from a clean state. Reset the period
+    // first if you want to change anything and regenerate — this keeps the pre-generation
+    // snapshot (see persistPlannerResult) meaningful and avoids reasoning about fairness
+    // across multiple partial runs.
+    if (period.status === 'generated') {
+      throw new HttpsError(
+        'failed-precondition',
+        'This period has already been generated. Reset it before generating again.'
+      );
+    }
+
     const surveyType = resolveSurveyType(period);
     const includeShiftStatusQuestions = surveyType === 'regularSemesterSurvey';
 
@@ -167,7 +178,10 @@ export const generateShiftPlan = onCall(
 
     // Compute unified role updates: passive/legacy corrections + new anchor promotions.
     // Applied in one write per user so there are no races between concurrent transforms.
-    const roleUpdates: Array<{ userId: string; roles: string[] }> = [];
+    // previousRoles is carried alongside so persistPlannerResult can snapshot it — "Reset
+    // period" needs to restore exactly this, otherwise a promoted new anchor would read as
+    // an experienced anchor (hasAnchorRole) on a later regenerate for the same period.
+    const roleUpdates: Array<{ userId: string; roles: string[]; previousRoles: string[] }> = [];
     for (const user of userList) {
       if (user.participationStatus === 'leave') continue;
 
@@ -190,7 +204,7 @@ export const generateShiftPlan = onCall(
         newRoles.some((r) => !current.includes(r));
 
       if (changed) {
-        roleUpdates.push({ userId: user.uid, roles: newRoles });
+        roleUpdates.push({ userId: user.uid, roles: newRoles, previousRoles: current });
       }
     }
 
@@ -928,6 +942,7 @@ export const generateShiftPlan = onCall(
       shifts,
       assignments: plannedAssignments,
       roleUpdates,
+      previousStatus: period.status ?? 'open',
       expectedSubmissions: requiredSurveyUsers.length,
       submittedCount: requiredSurveyUsers.length - missingSubmissionUserIdSet.size,
       assignedAnchorCount,

--- a/functions/src/shiftPlanning/helpers.ts
+++ b/functions/src/shiftPlanning/helpers.ts
@@ -111,7 +111,7 @@ export const toDate = (value: FirestoreDate | undefined): Date | null => {
   return null;
 };
 
-const shuffle = <T>(input: T[]): T[] => {
+export const shuffle = <T>(input: T[]): T[] => {
   const arr = [...input];
   for (let i = arr.length - 1; i > 0; i -= 1) {
     const j = Math.floor(Math.random() * (i + 1));

--- a/src/firebase/api/shiftPlanReset.ts
+++ b/src/firebase/api/shiftPlanReset.ts
@@ -1,0 +1,87 @@
+// "Reset period" — undoes a generated shift plan back to its pre-generation snapshot
+// (see functions/src/shiftPlanning/firebaseData.ts persistPlannerResult, which captures the
+// snapshot atomically with the one-and-only generate run for a period). Runs client-side,
+// same permission class as the existing manual engagement removal in ShiftAssignmentInfo.tsx.
+import { collection, deleteField, doc, DocumentReference, writeBatch } from "firebase/firestore";
+import { db } from "..";
+import { Engagement, ShiftPlanningPeriod } from "../../types/types-file";
+
+const env = import.meta.env.VITE_APP_ENV as string;
+
+const WRITE_BATCH_LIMIT = 450; // stay comfortably under Firestore's 500 ops/batch cap
+
+const getPeriodsCollection = () => collection(doc(collection(db, "env"), env), "shiftPlanningPeriods");
+const getEngagementsCollection = () => collection(doc(collection(db, "env"), env), "engagements");
+const getUsersCollection = () => collection(db, "users");
+
+type BatchOp =
+  | { kind: "delete"; ref: DocumentReference }
+  | { kind: "update"; ref: DocumentReference; data: Record<string, unknown> };
+
+const commitOpsInChunks = async (ops: BatchOp[]) => {
+  for (let i = 0; i < ops.length; i += WRITE_BATCH_LIMIT) {
+    const chunk = ops.slice(i, i + WRITE_BATCH_LIMIT);
+    const batch = writeBatch(db);
+    for (const op of chunk) {
+      if (op.kind === "delete") {
+        batch.delete(op.ref);
+      } else {
+        batch.update(op.ref, op.data);
+      }
+    }
+    await batch.commit();
+  }
+};
+
+export type ResetShiftPlanningPeriodResult = {
+  deletedEngagementCount: number;
+  restoredRoleCount: number;
+};
+
+export const resetShiftPlanningPeriod = async (params: {
+  period: ShiftPlanningPeriod;
+  periodEngagements: Engagement[];
+}): Promise<ResetShiftPlanningPeriodResult> => {
+  const { period, periodEngagements } = params;
+  const snapshot = period.preGenerationSnapshot;
+
+  if (!snapshot) {
+    throw new Error("This period has no pre-generation snapshot to reset to.");
+  }
+
+  const keepEngagementIds = new Set(snapshot.engagementIds);
+  const engagementsToDelete = periodEngagements.filter((engagement) => !keepEngagementIds.has(engagement.id));
+
+  const ops: BatchOp[] = engagementsToDelete.map((engagement) => ({
+    kind: "delete",
+    ref: doc(getEngagementsCollection(), engagement.id),
+  }));
+
+  for (const roleSnapshot of snapshot.roleSnapshots) {
+    ops.push({
+      kind: "update",
+      ref: doc(getUsersCollection(), roleSnapshot.userId),
+      data: { roles: roleSnapshot.roles },
+    });
+  }
+
+  ops.push({
+    kind: "update",
+    ref: doc(getPeriodsCollection(), period.id),
+    data: {
+      status: snapshot.status,
+      generatedAt: deleteField(),
+      generatedBy: deleteField(),
+      stats: deleteField(),
+      preGenerationSnapshot: deleteField(),
+    },
+  });
+
+  await commitOpsInChunks(ops);
+
+  return {
+    deletedEngagementCount: engagementsToDelete.length,
+    restoredRoleCount: snapshot.roleSnapshots.length,
+  };
+};
+

--- a/src/firebase/api/shiftSurveySeed.ts
+++ b/src/firebase/api/shiftSurveySeed.ts
@@ -1,0 +1,173 @@
+// Test-data helper for the shift-plan feature. Runs entirely client-side via the Firestore
+// client SDK (same as a normal survey submission) — no Cloud Function involved. Firestore
+// security rules are the actual enforcement boundary; this is only reachable by someone
+// already signed in with admin access to the page it's rendered on.
+import { collection, doc, DocumentReference, serverTimestamp, writeBatch } from "firebase/firestore";
+import { db } from "..";
+import { resolveSurveyType } from "./shiftPlanning";
+import { ShiftPlanningPeriod, Shift, Tender } from "../../types/types-file";
+
+const env = import.meta.env.VITE_APP_ENV as string;
+
+// Hides the button outside of dev — a convenience so it can't accidentally be clicked on a
+// production build, not a security boundary (Firestore rules are).
+export const isShiftSurveySeedingEnabled = env !== "prod";
+
+const WRITE_BATCH_LIMIT = 450; // stay comfortably under Firestore's 500 ops/batch cap
+
+const getResponsesCollection = () =>
+  collection(doc(collection(db, "env"), env), "shiftPlanningResponses");
+
+type SeedableUser = Pick<Tender, "uid" | "roles">;
+
+// mulberry32 — lets callers pass a seed for reproducible test fixtures; falls back to Math.random.
+const makeRng = (seed?: number): (() => number) => {
+  if (seed === undefined || seed === null || Number.isNaN(seed)) {
+    return Math.random;
+  }
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const shuffleWith = <T>(rng: () => number, input: T[]): T[] => {
+  const arr = [...input];
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+};
+
+// Satellite shifts (linkedShiftId set) share the primary shift's availability answer —
+// mirrors the lookup functions/src/shiftPlanning/generateShiftPlan.ts does when reading a response.
+const buildAvailabilityKeys = (shifts: Shift[]): string[] => {
+  const keys = new Set<string>();
+  for (const shift of shifts) {
+    keys.add(shift.linkedShiftId || shift.id);
+  }
+  return Array.from(keys);
+};
+
+const buildRandomResponse = (params: {
+  user: SeedableUser;
+  periodId: string;
+  availabilityKeys: string[];
+  anchorSeminarDays: string[];
+  rng: () => number;
+}): Record<string, unknown> => {
+  const { user, periodId, availabilityKeys, anchorSeminarDays, rng } = params;
+  const hasAnchorRole = (user.roles ?? []).includes("anchor");
+
+  const participationRoll = rng();
+  const participationStatus =
+    participationRoll < 0.85
+      ? "active"
+      : participationRoll < 0.93
+        ? "passive"
+        : participationRoll < 0.97
+          ? "legacy"
+          : "leave";
+
+  const isActive = participationStatus === "active";
+  // Experienced anchors mostly keep anchoring; a slice of everyone else opts in too, so the
+  // "new anchor" assignment path in generateShiftPlan.ts gets exercised.
+  const wantsAnchor = isActive && (hasAnchorRole ? rng() < 0.8 : rng() < 0.15);
+  const isNewAnchor = wantsAnchor && !hasAnchorRole;
+  const anchorOnly = wantsAnchor && rng() < 0.2;
+
+  const availability: Record<string, boolean> = {};
+  if (isActive) {
+    for (const key of availabilityKeys) {
+      // ~55% per-shift availability keeps most shifts fillable without everyone being
+      // available for everything.
+      availability[key] = rng() < 0.55;
+    }
+  }
+
+  const response: Record<string, unknown> = {
+    periodId,
+    userId: user.uid,
+    participationStatus,
+    wantsAnchor,
+    isNewAnchor,
+    availability,
+    anchorOnly,
+    seededTestData: true,
+    submittedAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  };
+
+  if (isNewAnchor && anchorSeminarDays.length > 0) {
+    const pickCount = 1 + Math.floor(rng() * Math.min(2, anchorSeminarDays.length));
+    response.anchorSeminarDays = shuffleWith(rng, anchorSeminarDays).slice(0, pickCount);
+  }
+
+  if (participationStatus === "passive") {
+    response.passiveReason = "Seeded test data for shift-plan QA";
+  }
+
+  return response;
+};
+
+const isEligibleSurveyUser = (user: Tender, requireNewbie: boolean): boolean =>
+  user.active === true &&
+  (user.roles ?? []).includes("tender") &&
+  (!requireNewbie || (user.roles ?? []).includes("newbie"));
+
+// Only ever creates/updates response docs, never deletes — every field is rewritten with
+// {merge: true} on each run, and admins are only granted create/update on this collection,
+// not delete (writing on behalf of another user was never a use case before this feature).
+const commitWritesInChunks = async (writes: Array<{ ref: DocumentReference; data: Record<string, unknown> }>) => {
+  for (let i = 0; i < writes.length; i += WRITE_BATCH_LIMIT) {
+    const chunk = writes.slice(i, i + WRITE_BATCH_LIMIT);
+    const batch = writeBatch(db);
+    for (const entry of chunk) {
+      batch.set(entry.ref, entry.data, { merge: true });
+    }
+    await batch.commit();
+  }
+};
+
+export type SeedShiftSurveyResponsesResult = {
+  seededCount: number;
+};
+
+export const seedShiftSurveyResponses = async (params: {
+  period: ShiftPlanningPeriod;
+  shifts: Shift[];
+  tenders: Tender[];
+  seed?: number;
+}): Promise<SeedShiftSurveyResponsesResult> => {
+  const { period, shifts, tenders, seed } = params;
+
+  if (shifts.length === 0) {
+    throw new Error("No shifts found for this period's events.");
+  }
+
+  const requireNewbie = resolveSurveyType(period) === "newbieShiftPlanning";
+  const eligibleUsers = tenders.filter((user) => isEligibleSurveyUser(user, requireNewbie));
+
+  if (eligibleUsers.length === 0) {
+    throw new Error("No eligible tenders found to generate responses for.");
+  }
+
+  const responsesCollection = getResponsesCollection();
+  const availabilityKeys = buildAvailabilityKeys(shifts);
+  const anchorSeminarDays = period.anchorSeminarDays ?? [];
+  const rng = makeRng(seed);
+
+  const writes = eligibleUsers.map((user) => ({
+    ref: doc(responsesCollection, `${period.id}_${user.uid}`),
+    data: buildRandomResponse({ user, periodId: period.id, availabilityKeys, anchorSeminarDays, rng }),
+  }));
+
+  await commitWritesInChunks(writes);
+
+  return { seededCount: eligibleUsers.length };
+};

--- a/src/hooks/useShiftPlanReset.ts
+++ b/src/hooks/useShiftPlanReset.ts
@@ -1,0 +1,35 @@
+// Standalone hook for "Reset period" — kept separate from useShiftPlanning.ts so this
+// undo-only functionality is easy to find and remove.
+import { message } from "antd";
+import { useCallback, useState } from "react";
+import { resetShiftPlanningPeriod } from "../firebase/api/shiftPlanReset";
+import { Engagement, ShiftPlanningPeriod } from "../types/types-file";
+
+const useShiftPlanReset = () => {
+  const [resetting, setResetting] = useState(false);
+
+  const resetPeriod = useCallback(async (params: {
+    period: ShiftPlanningPeriod;
+    periodEngagements: Engagement[];
+  }) => {
+    setResetting(true);
+    try {
+      const result = await resetShiftPlanningPeriod(params);
+      message.success(
+        `Reset complete: removed ${result.deletedEngagementCount} engagement(s), restored ${result.restoredRoleCount} role change(s).`
+      );
+      return result;
+    } catch (error) {
+      message.error(
+        `Failed to reset period: ${error instanceof Error ? error.message : "An unexpected error occurred."}`
+      );
+      return null;
+    } finally {
+      setResetting(false);
+    }
+  }, []);
+
+  return { resetting, resetPeriod };
+};
+
+export default useShiftPlanReset;

--- a/src/hooks/useShiftSurveySeed.ts
+++ b/src/hooks/useShiftSurveySeed.ts
@@ -1,0 +1,40 @@
+// Standalone hook for the test-data "seed survey" feature — kept separate from
+// useShiftPlanning.ts so the seed-only functionality is easy to find and remove.
+import { message } from "antd";
+import { useCallback, useState } from "react";
+import {
+  seedShiftSurveyResponses,
+  SeedShiftSurveyResponsesResult,
+} from "../firebase/api/shiftSurveySeed";
+import { Shift, ShiftPlanningPeriod, Tender } from "../types/types-file";
+
+const useShiftSurveySeed = () => {
+  const [seeding, setSeeding] = useState(false);
+
+  const seedSurveyResponses = useCallback(async (params: {
+    period: ShiftPlanningPeriod;
+    shifts: Shift[];
+    tenders: Tender[];
+    seed?: number;
+  }): Promise<SeedShiftSurveyResponsesResult | null> => {
+    setSeeding(true);
+    try {
+      const result = await seedShiftSurveyResponses(params);
+      message.success(`Seeded ${result.seededCount} test survey response(s).`);
+      return result;
+    } catch (error) {
+      message.error(
+        `Failed to seed test survey responses: ${
+          error instanceof Error ? error.message : "An unexpected error occurred."
+        }`
+      );
+      return null;
+    } finally {
+      setSeeding(false);
+    }
+  }, []);
+
+  return { seeding, seedSurveyResponses };
+};
+
+export default useShiftSurveySeed;

--- a/src/pages/admin/ShiftManagement/components/ResetPeriodButton.tsx
+++ b/src/pages/admin/ShiftManagement/components/ResetPeriodButton.tsx
@@ -1,0 +1,44 @@
+// Undoes a generated shift plan back to its pre-generation snapshot: deletes engagements
+// created by that run, restores the period's prior status, and reverts role changes
+// (new-anchor promotions, passive/legacy sync) so a later regenerate isn't corrupted by
+// stale role state. Only ever shown once a period has actually been generated.
+import { UndoOutlined } from "@ant-design/icons";
+import { Button, Popconfirm } from "antd";
+import { useMemo } from "react";
+import { useEngagementContext } from "../../../../contexts/EngagementContext";
+import { useShiftContext } from "../../../../contexts/ShiftContext";
+import useShiftPlanReset from "../../../../hooks/useShiftPlanReset";
+import { ShiftPlanningPeriod } from "../../../../types/types-file";
+
+type ResetPeriodButtonProps = {
+  period: ShiftPlanningPeriod;
+};
+
+export default function ResetPeriodButton({ period }: ResetPeriodButtonProps) {
+  const { shiftState } = useShiftContext();
+  const { engagementState } = useEngagementContext();
+  const { resetting, resetPeriod } = useShiftPlanReset();
+
+  const periodEngagements = useMemo(() => {
+    const periodShiftIds = new Set(
+      shiftState.shifts.filter((shift) => period.eventIds.includes(shift.eventId)).map((shift) => shift.id)
+    );
+    return engagementState.engagements.filter((engagement) => periodShiftIds.has(engagement.shiftId));
+  }, [engagementState.engagements, period.eventIds, shiftState.shifts]);
+
+  if (period.status !== "generated") {
+    return null;
+  }
+
+  return (
+    <Popconfirm
+      title="Reset period"
+      description="Undo the generated shift plan for this period? This deletes the engagements it created, restores the period to its pre-generation state, and reverts role changes (new anchor promotions, passive/legacy sync) made during generation. Survey responses are not affected."
+      onConfirm={() => resetPeriod({ period, periodEngagements })}
+    >
+      <Button danger icon={<UndoOutlined />} loading={resetting}>
+        Reset period
+      </Button>
+    </Popconfirm>
+  );
+}

--- a/src/pages/admin/ShiftManagement/components/SeedSurveyResponsesButton.tsx
+++ b/src/pages/admin/ShiftManagement/components/SeedSurveyResponsesButton.tsx
@@ -1,0 +1,49 @@
+// Test-data button for the shift-plan feature: fills in randomized-but-valid survey
+// responses for every eligible tender so the planner can be exercised end-to-end.
+// Runs entirely client-side via the Firestore client SDK — Firestore security rules are
+// the real enforcement boundary, not this button. Hidden outside dev as a convenience.
+import { ExperimentOutlined } from "@ant-design/icons";
+import { Button, Popconfirm } from "antd";
+import { useMemo } from "react";
+import { useShiftContext } from "../../../../contexts/ShiftContext";
+import { isShiftSurveySeedingEnabled } from "../../../../firebase/api/shiftSurveySeed";
+import useShiftSurveySeed from "../../../../hooks/useShiftSurveySeed";
+import useTenders from "../../../../hooks/useTenders";
+import { ShiftPlanningPeriod } from "../../../../types/types-file";
+
+type SeedSurveyResponsesButtonProps = {
+  period: ShiftPlanningPeriod;
+};
+
+export default function SeedSurveyResponsesButton({ period }: SeedSurveyResponsesButtonProps) {
+  const { shiftState } = useShiftContext();
+  const { tenderState } = useTenders();
+  const { seeding, seedSurveyResponses } = useShiftSurveySeed();
+
+  const periodShifts = useMemo(() => {
+    const periodEventIds = new Set(period.eventIds);
+    return shiftState.shifts.filter((shift) => periodEventIds.has(shift.eventId));
+  }, [period.eventIds, shiftState.shifts]);
+
+  if (!isShiftSurveySeedingEnabled) {
+    return null;
+  }
+
+  return (
+    <Popconfirm
+      title="Seed test survey responses"
+      description="Fill in randomized availability/anchor answers for every eligible tender in this period, overwriting any existing responses for those users? Only for testing the planner."
+      onConfirm={() =>
+        seedSurveyResponses({
+          period,
+          shifts: periodShifts,
+          tenders: tenderState.tenders,
+        })
+      }
+    >
+      <Button icon={<ExperimentOutlined />} loading={seeding}>
+        Seed test survey responses
+      </Button>
+    </Popconfirm>
+  );
+}

--- a/src/pages/admin/ShiftManagement/components/ShiftPlanningTab.tsx
+++ b/src/pages/admin/ShiftManagement/components/ShiftPlanningTab.tsx
@@ -2,6 +2,7 @@ import { RocketOutlined } from "@ant-design/icons";
 import { Alert, Button, Popconfirm, Space } from "antd";
 import Text from "antd/es/typography/Text";
 import ShiftEventInformationSection from "./ShiftEventInformationSection";
+import ResetPeriodButton from "./ResetPeriodButton";
 import SeedSurveyResponsesButton from "./SeedSurveyResponsesButton";
 import { Event, ShiftPlanningPeriod } from "../../../../types/types-file";
 
@@ -64,15 +65,23 @@ export default function ShiftPlanningTab({
             title="Generate shift plan"
             description={
               (missingSubmissions ?? 0) > 0
-                ? `${missingSubmissions} member(s) have not submitted availability and will be treated as leaving the bar. Generate new engagements for unassigned slots and create a new unpublished plan? Existing engagements are kept.`
-                : "Generate new engagements for unassigned slots in the selected period's shifts and create a new unpublished plan? Existing engagements are kept."
+                ? `${missingSubmissions} member(s) have not submitted availability and will be treated as leaving the bar. Generate engagements for this period's shifts and create a new unpublished plan?`
+                : "Generate engagements for this period's shifts and create a new unpublished plan?"
             }
             onConfirm={onGeneratePlan}
+            disabled={selectedPeriod.status === "generated"}
           >
-            <Button type="primary" icon={<RocketOutlined />} loading={generatingPlan}>
+            <Button
+              type="primary"
+              icon={<RocketOutlined />}
+              loading={generatingPlan}
+              disabled={selectedPeriod.status === "generated"}
+            >
               Generate shift plan
             </Button>
           </Popconfirm>
+
+          <ResetPeriodButton period={selectedPeriod} />
 
           <Popconfirm
             title={`Publish shifts for ${selectedPeriod.name}?`}

--- a/src/pages/admin/ShiftManagement/components/ShiftPlanningTab.tsx
+++ b/src/pages/admin/ShiftManagement/components/ShiftPlanningTab.tsx
@@ -2,6 +2,7 @@ import { RocketOutlined } from "@ant-design/icons";
 import { Alert, Button, Popconfirm, Space } from "antd";
 import Text from "antd/es/typography/Text";
 import ShiftEventInformationSection from "./ShiftEventInformationSection";
+import SeedSurveyResponsesButton from "./SeedSurveyResponsesButton";
 import { Event, ShiftPlanningPeriod } from "../../../../types/types-file";
 
 type ShiftPlanningTabProps = {
@@ -79,6 +80,8 @@ export default function ShiftPlanningTab({
           >
             <Button size="middle">{`Publish shifts for ${selectedPeriod.name}`}</Button>
           </Popconfirm>
+
+          <SeedSurveyResponsesButton period={selectedPeriod} />
 
           {generationSummary && <Alert type="success" showIcon message={generationSummary} />}
           {generationWarnings.length > 0 && (

--- a/src/types/types-file.ts
+++ b/src/types/types-file.ts
@@ -255,6 +255,12 @@ export type ShiftPlanningSurveyType =
   | "excludeSemesterStatus"
   | "newbieShiftPlanning";
 
+export interface ShiftPlanningPeriodSnapshot {
+  status: ShiftPlanningPeriodStatus;
+  engagementIds: string[];
+  roleSnapshots: Array<{ userId: string; roles: string[] }>;
+}
+
 export interface ShiftPlanningPeriod {
   id: string;
   key?: string;
@@ -280,6 +286,9 @@ export interface ShiftPlanningPeriod {
     unfilledAnchorSlots?: number;
     unfilledTenderSlots?: number;
   };
+  // Captured right before the one-and-only generate run for this period, so "Reset period"
+  // can undo it exactly — see functions/src/shiftPlanning/firebaseData.ts persistPlannerResult.
+  preGenerationSnapshot?: ShiftPlanningPeriodSnapshot;
 }
 
 export interface ShiftPlanningResponse {


### PR DESCRIPTION
## Summary
- Reworks shift plan generation to use dynamic, self-adjusting caps (scaled to each period's own shift-to-member ratio) instead of fixed numbers (5 total, 2 opening, 2 closing), and replaces the sequential opening→closing→middle fill with a single level-filled pass so no category can exhaust the eligible pool before others are even considered.
- Treats mandatory events as a guaranteed add-on layer, scheduled after non-mandatory assignment so mandatory placement can steer toward whichever category (opening/closing) someone's behind on, without ever being blocked by the fairness caps that govern non-mandatory scheduling.
- Fixes a one-shift-per-event gap found during review: an experienced anchor could previously be matched to two different shifts of the same event.
- Adds a "Reset period" admin action that undoes a generated shift plan back to its pre-generation snapshot (engagements, period status, and role changes), guarded by a Cloud Function check that blocks regenerating an already-generated period.
- Adds a client-side "Seed test survey responses" admin action (dev-only) for generating randomized-but-valid survey responses to exercise the planner end-to-end without manually filling out the survey as every member.
- Documents the full generation pipeline with a Mermaid diagram and a verified requirements checklist in `functions/src/shiftPlanning/GENERATE_SHIFT_PLAN.md`.

## Test plan
- [ ] `npm run build` in `functions/` and deploy to a dev project before relying on this (Cloud Function changes are not live until deployed)
- [ ] Seed a period with test survey responses via the new admin button, then Generate and confirm assignments are spread evenly and mandatory events are fully covered
- [ ] Confirm avoid-shift-with pairs never land on the same shift
- [ ] Try Reset on a freshly generated period and confirm it restores exactly to the pre-generation state
- [ ] Try Generate twice in a row on the same period without resetting and confirm it's rejected

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>